### PR TITLE
Fix r2modman/thunderstore profile importing on Linux

### DIFF
--- a/src-tauri/src/manager/importer/r2modman.rs
+++ b/src-tauri/src/manager/importer/r2modman.rs
@@ -331,12 +331,31 @@ fn import_cache(mut path: PathBuf, app: &AppHandle) -> Result<()> {
     Ok(())
 }
 
+#[cfg(not(target_os = "linux"))]
 fn find_paths() -> ManagerData<PathBuf> {
     let data_dir = tauri::api::path::data_dir().unwrap();
 
     return ManagerData {
         r2modman: check_dir(data_dir.join("r2modmanPlus-local")),
         thunderstore: check_dir(data_dir.join("Thunderstore Mod Manager").join("DataFolder")),
+    };
+
+    fn check_dir(path: PathBuf) -> Option<PathBuf> {
+        match path.exists() {
+            true => Some(path),
+            false => None,
+        }
+    }
+}
+
+// r2modman uses the config dir instead of the data dir on linux.
+#[cfg(target_os = "linux")]
+fn find_paths() -> ManagerData<PathBuf> {
+    let config_dir = tauri::api::path::config_dir().unwrap();
+
+    return ManagerData {
+        r2modman: check_dir(config_dir.join("r2modmanPlus-local")),
+        thunderstore: check_dir(config_dir.join("Thunderstore Mod Manager").join("DataFolder")),
     };
 
     fn check_dir(path: PathBuf) -> Option<PathBuf> {

--- a/src-tauri/src/manager/importer/r2modman.rs
+++ b/src-tauri/src/manager/importer/r2modman.rs
@@ -331,31 +331,16 @@ fn import_cache(mut path: PathBuf, app: &AppHandle) -> Result<()> {
     Ok(())
 }
 
-#[cfg(not(target_os = "linux"))]
 fn find_paths() -> ManagerData<PathBuf> {
-    let data_dir = tauri::api::path::data_dir().unwrap();
+    let parent_dir = match cfg!(target_os = "linux") {
+        // r2modman uses the config dir instead of the data dir on linux.
+        true => tauri::api::path::config_dir(),
+        false => tauri::api::path::data_dir(),
+    }.unwrap();
 
     return ManagerData {
-        r2modman: check_dir(data_dir.join("r2modmanPlus-local")),
-        thunderstore: check_dir(data_dir.join("Thunderstore Mod Manager").join("DataFolder")),
-    };
-
-    fn check_dir(path: PathBuf) -> Option<PathBuf> {
-        match path.exists() {
-            true => Some(path),
-            false => None,
-        }
-    }
-}
-
-// r2modman uses the config dir instead of the data dir on linux.
-#[cfg(target_os = "linux")]
-fn find_paths() -> ManagerData<PathBuf> {
-    let config_dir = tauri::api::path::config_dir().unwrap();
-
-    return ManagerData {
-        r2modman: check_dir(config_dir.join("r2modmanPlus-local")),
-        thunderstore: check_dir(config_dir.join("Thunderstore Mod Manager").join("DataFolder")),
+        r2modman: check_dir(parent_dir.join("r2modmanPlus-local")),
+        thunderstore: check_dir(parent_dir.join("Thunderstore Mod Manager").join("DataFolder")),
     };
 
     fn check_dir(path: PathBuf) -> Option<PathBuf> {


### PR DESCRIPTION
r2modman/thunderstore keep their profiles under config dirs (`~/.config/`) instead of data dirs (`~/.local/share/`).
this PR adds linux specific handling of this difference.

These changes fix r2modman/thunderstore profile importing on Linux