### PR TITLE
Prefer platform independent wording for opening profile dir

### DIFF
--- a/src/lib/menu/Menubar.svelte
+++ b/src/lib/menu/Menubar.svelte
@@ -75,7 +75,7 @@
 				class="bg-gray-800 shadow-xl flex-col flex gap-0.5 py-1 mt-0.5 rounded-lg border border-gray-600"
 			>
 				<MenubarItem onClick={() => invokeCommand('open_profile_dir')}
-					>Open profile folder</MenubarItem
+					>Open profile directory</MenubarItem
 				>
 				<MenubarItem onClick={() => invokeCommand('open_bepinex_log')}>Open game logs</MenubarItem>
 				<MenubarItem onClick={() => invokeCommand('open_gale_log')}>Open gale logs</MenubarItem>

--- a/src/lib/menu/Menubar.svelte
+++ b/src/lib/menu/Menubar.svelte
@@ -75,7 +75,7 @@
 				class="bg-gray-800 shadow-xl flex-col flex gap-0.5 py-1 mt-0.5 rounded-lg border border-gray-600"
 			>
 				<MenubarItem onClick={() => invokeCommand('open_profile_dir')}
-					>Show profile in explorer</MenubarItem
+					>Open profile folder</MenubarItem
 				>
 				<MenubarItem onClick={() => invokeCommand('open_bepinex_log')}>Open game logs</MenubarItem>
 				<MenubarItem onClick={() => invokeCommand('open_gale_log')}>Open gale logs</MenubarItem>


### PR DESCRIPTION
Explorer is a Windows specific program, this PR changes the wording from "Show profile in explorer" to "Open profile folder", which ends up being more consistent with the rest of the apps wording.