### PR TITLE
Fix deep links on Linux

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -51,10 +51,8 @@ fn setup(app: AppHandle) -> anyhow::Result<()> {
 }
 
 fn main() {
-    if !cfg!(target_os = "linux") {
-        // doesn't work on linux for some reason :/
-        tauri_plugin_deep_link::prepare("com.kesomannen.modmanager");
-    }
+    // Identifier must match identifier found in tauri.conf.json
+    tauri_plugin_deep_link::prepare("com.kesomannen.gale");
 
     let mut builder = tauri::Builder::default();
     

--- a/src-tauri/src/manager/downloader.rs
+++ b/src-tauri/src/manager/downloader.rs
@@ -30,9 +30,7 @@ pub mod updater;
 pub fn setup(app: &AppHandle) -> Result<()> {
     app.manage(Mutex::new(InstallState::default()));
 
-    if !cfg!(target_os = "linux") {
-        tauri_plugin_deep_link::register("ror2mm", deep_link_handler(app.clone()))?;
-    }
+    tauri_plugin_deep_link::register("ror2mm", deep_link_handler(app.clone()))?;
 
     Ok(())
 }


### PR DESCRIPTION
The identifier you register with `prepare` is supposed to match the identifier found in tauri.conf.json. Changing the identifier fixed "Install with Mod Manager" functionality on Linux.

I only tested this change on Linux. Make sure this doesn't break the other platforms.