### PR TITLE
Import local mod from ZIP file

### DIFF
--- a/src-tauri/src/manager/importer.rs
+++ b/src-tauri/src/manager/importer.rs
@@ -246,6 +246,12 @@ async fn import_local_mod(path: PathBuf, app: &AppHandle) -> Result<()> {
 
             local_mod.icon = plugin_path.join("icon.png").exists_or_none();
         }
+        LocalModKind::Zip => {
+            installer::install_from_zip(&path, &profile.path, &local_mod.name)
+                .context("failed to install local mod")?;
+
+            local_mod.icon = plugin_path.join("icon.png").exists_or_none();
+        }
         LocalModKind::Dll => {
             let file_name = path.file_name().unwrap();
 
@@ -264,6 +270,7 @@ async fn import_local_mod(path: PathBuf, app: &AppHandle) -> Result<()> {
 #[derive(PartialEq, Eq)]
 enum LocalModKind {
     Package,
+    Zip,
     Dll,
 }
 
@@ -272,6 +279,7 @@ fn read_local_mod(path: &Path) -> Result<(LocalMod, LocalModKind)> {
         true => LocalModKind::Package,
         false => match path.extension() {
             Some(ext) if ext == "dll" => LocalModKind::Dll,
+            Some(ext) if ext == "zip" => LocalModKind::Zip,
             _ => bail!("unsupported file type"),
         },
     };
@@ -280,6 +288,19 @@ fn read_local_mod(path: &Path) -> Result<(LocalMod, LocalModKind)> {
         LocalModKind::Package => path.join("manifest.json").exists_or_none().map(|path| {
             util::fs::read_json::<PackageManifest>(&path).context("failed to read mod manifest")
         }),
+        LocalModKind::Zip => Some(
+            util::fs::open_zip(path)
+                .context("failed to read zip package")
+                .and_then(|mut archive| {
+                    let manifest = archive
+                        .by_name("manifest.json")
+                        .context("failed to find mod manifest")?;
+                    let manifest = serde_json::from_reader::<_, PackageManifest>(manifest)
+                        .context("failed to read mod manifest")?;
+
+                    Ok(manifest)
+                }),
+        ),
         LocalModKind::Dll => None,
     }
     .transpose()?;

--- a/src-tauri/src/manager/importer.rs
+++ b/src-tauri/src/manager/importer.rs
@@ -247,7 +247,7 @@ async fn import_local_mod(path: PathBuf, app: &AppHandle) -> Result<()> {
             local_mod.icon = plugin_path.join("icon.png").exists_or_none();
         }
         LocalModKind::Zip => {
-            installer::install_from_zip(&path, &profile.path, &local_mod.name)
+            installer::install_from_zip(&path, &profile.path, &local_mod.name, &prefs)
                 .context("failed to install local mod")?;
 
             local_mod.icon = plugin_path.join("icon.png").exists_or_none();

--- a/src-tauri/src/manager/installer.rs
+++ b/src-tauri/src/manager/installer.rs
@@ -144,6 +144,21 @@ pub fn install_from_disk(src: &Path, dest: &Path, full_name: &str) -> Result<()>
     }
 }
 
+pub fn install_from_zip(src: &Path, dest: &Path, full_name: &str) -> Result<()> {
+    let target_dir = util::path::app_cache_dir().join(format!("extract_{full_name}"));
+    let zipfile = fs::File::open(src)?;
+
+    // temporarily extract the zip so the built in install from disk method can be used
+    util::zip::extract(zipfile, &target_dir)?;
+
+    install_from_disk(&target_dir, dest, full_name)?;
+
+    // clean up the leftovers
+    fs::remove_dir_all(target_dir)?;
+
+    Ok(())
+}
+
 fn install_default(src: &Path, dest: &Path, mod_name: &str) -> Result<()> {
     let bepinex = dest.join("BepInEx");
     let plugin_dir = bepinex.join("plugins").join(mod_name);

--- a/src-tauri/src/manager/installer.rs
+++ b/src-tauri/src/manager/installer.rs
@@ -144,11 +144,14 @@ pub fn install_from_disk(src: &Path, dest: &Path, full_name: &str) -> Result<()>
     }
 }
 
-pub fn install_from_zip(src: &Path, dest: &Path, full_name: &str) -> Result<()> {
-    let target_dir = util::path::app_cache_dir().join(format!("extract_{full_name}"));
+pub fn install_from_zip(src: &Path, dest: &Path, full_name: &str, prefs: &Prefs) -> Result<()> {
+    let mut target_dir = prefs.temp_dir.get().join("extract");
+    fs::create_dir_all(&target_dir)?;
+    target_dir.push(full_name);
+
     let zipfile = fs::File::open(src)?;
 
-    // temporarily extract the zip so the built in install from disk method can be used
+    // temporarily extract the zip so the same install from disk method can be used
     util::zip::extract(zipfile, &target_dir)?;
 
     install_from_disk(&target_dir, dest, full_name)?;

--- a/src-tauri/src/util/fs.rs
+++ b/src-tauri/src/util/fs.rs
@@ -1,5 +1,8 @@
 use std::{
-    ffi::OsStr, fs::{self}, io::{self}, path::{Path, PathBuf}
+    ffi::OsStr,
+    fs::{self},
+    io::{self, BufReader},
+    path::{Path, PathBuf},
 };
 
 use serde::{de::DeserializeOwned, Serialize};
@@ -59,6 +62,14 @@ pub fn read_json<T: DeserializeOwned>(path: impl AsRef<Path>) -> anyhow::Result<
     let result = serde_json::from_reader(reader)?;
 
     Ok(result)
+}
+
+pub fn open_zip(path: impl AsRef<Path>) -> anyhow::Result<zip::ZipArchive<BufReader<fs::File>>> {
+    let file = fs::File::open(path)?;
+    let reader = io::BufReader::new(file);
+    let archive = zip::ZipArchive::new(reader)?;
+
+    Ok(archive)
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/lib/menu/Menubar.svelte
+++ b/src/lib/menu/Menubar.svelte
@@ -39,7 +39,7 @@
 
 	const appWindow = getCurrentWindow();
 
-	async function importLocalPackage() {
+	async function importModDir() {
 		let path = await open({
 			directory: true,
 			title: 'Select the directory containing the mod package'
@@ -49,24 +49,14 @@
 		invokeCommand('import_local_mod', { path });
 	}
 
-	async function importLocalZIP() {
+	async function importModFile() {
 		let path = await open({
-			title: 'Select the ZIP to import',
-			filters: [{ name: 'ZIP file', extensions: ['zip'] }]
+			title: 'Select the mod file to import',
+			filters: [{ name: 'Dll or zip', extensions: ['dll', 'zip'] }]
 		});
 
 		if (!path) return;
-		invokeCommand('import_local_mod', { path: path.path });
-	}
-
-	async function importLocalDLL() {
-		let path = await open({
-			title: 'Select the DLL to import',
-			filters: [{ name: 'DLL file', extensions: ['dll'] }]
-		});
-
-		if (!path) return;
-		invokeCommand('import_local_mod', { path: path.path });
+		invokeCommand('import_local_mod', { path });
 	}
 
 	async function importFile() {
@@ -176,9 +166,8 @@
 			>
 				<MenubarItem on:click={() => (importProfileOpen = true)}>...profile from code</MenubarItem>
 				<MenubarItem on:click={importFile}>...profile from file</MenubarItem>
-				<MenubarItem on:click={importLocalPackage}>...local mod from package</MenubarItem>
-				<MenubarItem on:click={importLocalZIP}>...local mod from ZIP</MenubarItem>
-				<MenubarItem on:click={importLocalDLL}>...local mod from DLL</MenubarItem>
+				<MenubarItem on:click={importModFile}>...local mod from file</MenubarItem>
+				<MenubarItem on:click={importModDir}>...local mod from directory</MenubarItem>
 				<MenubarItem on:click={() => (importR2Open = true)}>...profiles from r2modman</MenubarItem>
 			</Menubar.Content>
 		</Menubar.Menu>

--- a/src/lib/menu/Menubar.svelte
+++ b/src/lib/menu/Menubar.svelte
@@ -49,6 +49,16 @@
 		invokeCommand('import_local_mod', { path });
 	}
 
+	async function importLocalZIP() {
+		let path = await open({
+			title: 'Select the ZIP to import',
+			filters: [{ name: 'ZIP file', extensions: ['zip'] }]
+		});
+
+		if (!path) return;
+		invokeCommand('import_local_mod', { path: path.path });
+	}
+
 	async function importLocalDLL() {
 		let path = await open({
 			title: 'Select the DLL to import',
@@ -56,7 +66,7 @@
 		});
 
 		if (!path) return;
-		invokeCommand('import_local_mod', { path });
+		invokeCommand('import_local_mod', { path: path.path });
 	}
 
 	async function importFile() {
@@ -167,6 +177,7 @@
 				<MenubarItem on:click={() => (importProfileOpen = true)}>...profile from code</MenubarItem>
 				<MenubarItem on:click={importFile}>...profile from file</MenubarItem>
 				<MenubarItem on:click={importLocalPackage}>...local mod from package</MenubarItem>
+				<MenubarItem on:click={importLocalZIP}>...local mod from ZIP</MenubarItem>
 				<MenubarItem on:click={importLocalDLL}>...local mod from DLL</MenubarItem>
 				<MenubarItem on:click={() => (importR2Open = true)}>...profiles from r2modman</MenubarItem>
 			</Menubar.Content>


### PR DESCRIPTION
This PR adds support for importing local mods from ZIP files directly, without having to extract them first.

This PR also immediately addresses a regression with importing local files, as the `open` tauri dialog returns an [`OpenDialogReturn<T>`](https://v2.tauri.app/reference/javascript/dialog/#opendialogreturnt) on files, instead of just a `string`/`string[]` (file paths).

The import strategy is actually pretty basic. Since most of the import logic is already in the "import from package" pipeline, importing from a zip simply just extracts the zip file into a temp directory, performs the "import from package" logic, and then deletes the extracted zip contents from the temp directory.

It would be a bit nicer if this actually read and extracted the files from the zip directly without relying on the "import from package" code, but that would require quite a bit of code duplication (at least for how the `installer.rs` is currently written, especially with the custom BepInExPack import code), hence why the simple approach for now.