### PR TITLE
Fix single pixel top border not being draggable

### DIFF
--- a/src/lib/menu/Menubar.svelte
+++ b/src/lib/menu/Menubar.svelte
@@ -120,6 +120,9 @@
 </script>
 
 <div data-tauri-drag-region class="h-8 flex bg-gray-800 flex-shrink-0">
+	<!-- Fix for top border not being draggable -->
+	<div data-tauri-drag-region class="fixed top-0 left-0 w-full h-[1px] z-50" />
+
 	<Menubar.Root class="py-1 flex items-center">
 		<img src="favicon.png" alt="Gale logo" class="ml-4 mr-2 h-5 w-5 opacity-50" />
 		<Menubar.Menu>


### PR DESCRIPTION
Minor issue, but pretty annoying nonetheless. Some users who have their Gale window maximized and try to drag it from the top of their screen will hit the CSS border created by the `<main>` element, thereby missing the `data-tauri-drag-region`.

This is a pretty hacky fix by just creating a 1 pixel high, invisible and draggable `<div>` on the top of the window, that spans the entire width.