### PR TITLE
Fix forgotten variable causing installed icon not to show up

### DIFF
--- a/src/routes/mods/+page.svelte
+++ b/src/routes/mods/+page.svelte
@@ -96,6 +96,7 @@
 	bind:mods
 	queryArgs={modQuery}
 	{sortOptions}
+	showInstalledIcon
 	on:onModCtrlClicked={({ detail: { mod } }) => installLatest(mod)}
 >
 	<div slot="details" class="flex mt-2 text-lg text-white">


### PR DESCRIPTION
Not exactly sure when this happened, but the `showInstalledIcon` property was somehow reverted to `false` during a commit, causing the mod-installed icons not to show up. Woops.

This tiny PR fixes that.