### PR TITLE
enable gzip for http requests

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -46,7 +46,7 @@ open = "5.1"
 itertools = "0.13"
 zip = "0.6"
 uuid = { version = "1", features = ["serde"] }
-reqwest = { version = "0.12", features = ["json", "stream"] }
+reqwest = { version = "0.12", features = ["json", "stream", "gzip"] }
 walkdir = "2"
 typeshare = "1"
 image = "0.25"


### PR DESCRIPTION
The speedup is quite substential. I went from downloading the Lethal Company mod index in about 1m+ to only 12s on my internet connection.