### PR TITLE
Fix "last updated" timestamp displayed as NaN

### DIFF
--- a/src-tauri/src/thunderstore/query.rs
+++ b/src-tauri/src/thunderstore/query.rs
@@ -185,7 +185,7 @@ impl IntoFrontendMod for BorrowedMod<'_> {
             contains_nsfw: pkg.has_nsfw_content,
             uuid: pkg.uuid4,
             is_installed: profile.has_mod(&pkg.uuid4),
-            last_updated: Some(pkg.versions[0].date_created.to_string()),
+            last_updated: Some(pkg.versions[0].date_created.to_rfc3339()),
             versions: pkg
                 .versions
                 .iter()


### PR DESCRIPTION
Before:
![image](https://github.com/user-attachments/assets/c43e1b1a-904e-45f8-9152-e30c4bfcbccf)

After:
![image](https://github.com/user-attachments/assets/4ce90dc3-9d58-4ae7-92bd-09f3d687492c)
