### PR TITLE
Fix Shimloader Installer's extraction of some DLLs

### DIFF
--- a/src-tauri/src/profile/install/installers/shimloader.rs
+++ b/src-tauri/src/profile/install/installers/shimloader.rs
@@ -6,7 +6,7 @@ use std::{
 
 use eyre::{Context, Result};
 
-use super::{PackageZip, PackageInstaller};
+use super::{PackageInstaller, PackageZip};
 use crate::profile::{
     install::{self},
     Profile, ProfileMod,
@@ -33,7 +33,7 @@ impl PackageInstaller for ShimloaderInstaller {
 
             Ok(match next.to_str() {
                 Some("dwmapi.dll") => {
-                    //The Shimloader package has 2 dwmapi.dll files, the one inside "UE4SS" doesn't seem to work.
+                    // The Shimloader package has 2 dwmapi.dll files, the one inside "UE4SS" doesn't seem to work.
                     if in_ue4ss {
                         return Ok(None);
                     }
@@ -62,7 +62,7 @@ impl PackageInstaller for ShimloaderInstaller {
         _profile_mod: &ProfileMod,
         profile: &Profile,
     ) -> Result<()> {
-        for file in ["dwmapi.dll", "ue4ss.dll", "UE4SS-settings.ini"] {
+        for file in ["dwmapi.dll", "UE4SS.dll", "UE4SS-settings.ini"] {
             install::fs::toggle_file(profile.path.join(file), enabled)?;
         }
 
@@ -70,7 +70,7 @@ impl PackageInstaller for ShimloaderInstaller {
     }
 
     fn uninstall(&mut self, _profile_mod: &ProfileMod, profile: &Profile) -> Result<()> {
-        for file in ["dwmapi.dll", "ue4ss.dll", "UE4SS-settings.ini"] {
+        for file in ["dwmapi.dll", "UE4SS.dll", "UE4SS-settings.ini"] {
             fs::remove_file(profile.path.join(file))?;
         }
 

--- a/src-tauri/src/profile/install/installers/shimloader.rs
+++ b/src-tauri/src/profile/install/installers/shimloader.rs
@@ -21,9 +21,9 @@ impl PackageInstaller for ShimloaderInstaller {
 
         install::fs::extract(archive, dest, |relative_path| {
             let mut components = relative_path.components();
-            let in_ue45ss = relative_path.starts_with("UE4SS");
-            
-            if in_ue45ss {
+            let in_ue4ss = relative_path.starts_with("UE4SS");
+
+            if in_ue4ss {
                 components.next();
             }
 
@@ -33,8 +33,8 @@ impl PackageInstaller for ShimloaderInstaller {
 
             Ok(match next.to_str() {
                 Some("dwmapi.dll") => {
-                    //The Shimloader package has 2 dwmapi.dll files, the one inside "UE45SS" doesn't seem to work.
-                    if in_ue45ss {
+                    //The Shimloader package has 2 dwmapi.dll files, the one inside "UE4SS" doesn't seem to work.
+                    if in_ue4ss {
                         return Ok(None);
                     }
 

--- a/src-tauri/src/profile/install/installers/shimloader.rs
+++ b/src-tauri/src/profile/install/installers/shimloader.rs
@@ -21,8 +21,9 @@ impl PackageInstaller for ShimloaderInstaller {
 
         install::fs::extract(archive, dest, |relative_path| {
             let mut components = relative_path.components();
-
-            if relative_path.starts_with("UE4SS") {
+            let in_ue45ss = relative_path.starts_with("UE4SS");
+            
+            if in_ue45ss {
                 components.next();
             }
 
@@ -31,7 +32,15 @@ impl PackageInstaller for ShimloaderInstaller {
             };
 
             Ok(match next.to_str() {
-                Some("dwmapi.dll" | "ue4ss.dll" | "UE4SS-settings.ini") => {
+                Some("dwmapi.dll") => {
+                    //The Shimloader package has 2 dwmapi.dll files, the one inside "UE45SS" doesn't seem to work.
+                    if in_ue45ss {
+                        return Ok(None);
+                    }
+
+                    Some(Cow::Borrowed(components.as_path()))
+                }
+                Some("UE4SS.dll" | "UE4SS-settings.ini") => {
                     Some(Cow::Borrowed(components.as_path()))
                 }
                 Some("Mods") => {


### PR DESCRIPTION
Fixes some Shimloader files not being correctly extracted

Specifically:
`dwmapi.dll` which was overwritten by the version inside the "UE4SS" folder,
`UE4SS.dll` which wasn't extracted because the casing was different