### PR TITLE
Remove unstable feature flag from Tauri

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -17,7 +17,7 @@ path = "src/main.rs"
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = [ "protocol-asset", "unstable"] }
+tauri = { version = "2", features = [ "protocol-asset" ] }
 tauri-plugin-deep-link = "2"
 tauri-plugin-window-state = "2"
 tauri-plugin-dialog = "2"

--- a/src-tauri/src/deep_link.rs
+++ b/src-tauri/src/deep_link.rs
@@ -17,7 +17,7 @@ pub fn handle(app: &AppHandle, args: Vec<String>) -> bool {
         return false;
     };
 
-    app.get_window("main")
+    app.get_webview_window("main")
         .expect("app should have main window")
         .set_focus()
         .ok();


### PR DESCRIPTION
Refs #226 

The unstable feature flag breaks being able to resize the window on Linux. I found that the unstable flag was originally added way back when Tauri v2 was itself in beta but I couldn't find anything specifically requiring it nowadays.

https://github.com/Kesomannen/gale/pull/47
https://github.com/Kesomannen/gale/commit/777dc214ee8c3346668a919c1d09f3a7ca15f646

I did run the release CI against these changes with a few modifications, and will be daily driving this build and will update if I encounter any issues.