### PR TITLE
fix: slow upwards scrolling

### DIFF
--- a/src/lib/components/ui/VirtualList.svelte
+++ b/src/lib/components/ui/VirtualList.svelte
@@ -130,7 +130,9 @@
 			}
 
 			const d = actual_height - expected_height;
-			viewport.scrollTo(0, scrollTop + d);
+			if (d !== 0) {
+				viewport.scrollTo(0, scrollTop + d);
+			}
 		}
 
 		// TODO if we overestimated the space these


### PR DESCRIPTION
the cause was the constant viewport.scrollTo calls when attempting to scroll up

the jump prevention code is only going to do anything when the actual_height and expected_height aren't equal due to different height elements within the list, since they're all the same height they are always equal and d is always 0. the viewport.scrollTo calls weren't really doing anything other than causing #17. we can just check if d is not 0 before going ahead.

i presume this was a linux only issue due to the different embedded browsers used by tauri on different platforms, Edge WebView2 likely does literally nothing when you call viewport.scrollTo with the scrollTop of the element

before:
[Kooha-2025-07-08-14-02-07.webm](https://github.com/user-attachments/assets/b9907119-3314-4a64-b842-bd2dd39c4d30)

after:
[Kooha-2025-07-08-14-01-33.webm](https://github.com/user-attachments/assets/4b13ed18-40e2-4999-9f16-107b7665e14e)

