### PR TITLE
Set working directory to game folder for direct launch mode

### DIFF
--- a/src-tauri/src/profile/launch/mod.rs
+++ b/src-tauri/src/profile/launch/mod.rs
@@ -86,6 +86,10 @@ impl ManagedGame {
         }
         .unwrap_or_else(|| exe_path(game_dir).map(Command::new))?;
 
+        if matches!(launch_mode, LaunchMode::Direct { .. }) {
+            command.current_dir(game_dir);
+        }
+
         let profile = self.active_profile();
 
         mod_loader::add_args(&mut command, &profile.path, &self.game.mod_loader)?;


### PR DESCRIPTION
When using Direct launch mode, games inherit Gale's working directory instead of running from their game folder. This breaks games that expect to run from their installation directory.

For example, Resonite crashes trying to write logs to `System32: System.UnauthorizedAccessException: Access to the path 'C\WINDOWS\system32\Resonite.Host.Crash.638945730864408595.log' is denied`.

This change sets the working directory to the game's folder when using Direct launch mode. While not all games require this, it's the safer default to prevent crashes and file access issues.