### PR TITLE
update reqwest to 0.13.1 and reqwest-websocket to 0.6.0

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -45,7 +45,7 @@ open = "5"
 itertools = "0.13"
 zip = { version = "2", features = ["deflate"] }
 uuid = { version = "1", features = ["v4", "serde"] }
-reqwest = { version = "0.12", features = ["json", "stream", "gzip", "native-tls"] }
+reqwest = { version = "0.13.1", features = ["json", "stream", "gzip"] }
 walkdir = "2"
 image = "0.25"
 semver = { version = "1", features = ["serde"] }
@@ -76,7 +76,7 @@ steamlocate = "2"
 flate2 = "1"
 font-kit = "0.14"
 internment = { version = "0.8.6", features = ["serde"] }
-reqwest-websocket = { version = "0.5.0", features = ["json"] }
+reqwest-websocket = { version = "0.6.0", features = ["json"] }
 
 [target.'cfg(target_os="windows")'.dependencies]
 winreg = "0.52"

--- a/src-tauri/src/profile/sync/socket.rs
+++ b/src-tauri/src/profile/sync/socket.rs
@@ -5,7 +5,7 @@ use futures_util::{
     stream::{SplitSink, SplitStream},
     SinkExt, StreamExt,
 };
-use reqwest_websocket::{RequestBuilderExt, WebSocket};
+use reqwest_websocket::{Upgrade, WebSocket};
 use serde::{Deserialize, Serialize};
 use tauri::AppHandle;
 use tokio::sync::mpsc;


### PR DESCRIPTION
I also removed the `native-tls` tag from reqwest, to fix some proxy(or VPN) compatibility issues, which should fix #247 and possibly #496.

In my test:
1. with `native-tls`(or `native-tls-no-alpn`) tag and proxy enabled, gale throws  `error while fetching mods from Thunderstore: error sending request for url (https://thunderstore.io/c/xxx/api/v1/package-listing-index/): client error (Connect): unexpected EOF during handshake` on fetching mods list.
2. without `native-tls` tag it works fine while proxy is enabled.

I found this solution by checking some discussions in reqwest's github issues.