### PR TITLE
feat: Add AI-powered translation for mod names, descriptions, and con…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+### Added
+
+- AI-powered translation for mod names, descriptions, and config entries
+  - Support any OpenAI-compatible API (OpenAI, DeepSeek, Moonshot, etc.)
+  - Batch translation with configurable batch size
+  - Translation cache with persistent storage in local database
+  - Auto-translation when browsing mod list
+  - Manual translation button in mod details page
+  - Toggle switch to show/hide translations
+  - Config entry translation
+  - Search support for translated names (Chinese, Japanese, Korean, etc.)
+  - URL auto-completion for API endpoint
+  - Show/hide API key toggle
+
 ### Changed
 
 - Made Inter the default font instead of Nunito Sans

--- a/README.md
+++ b/README.md
@@ -14,6 +14,26 @@ The modern and lightweight mod manager for [Thunderstore](https://thunderstore.i
 - Tiny download size and resource usage
 - Feature-rich mod config editor
 - Automatic profile syncing (beta)
+- AI-powered translation for mod names, descriptions, and config entries (NEW)
+
+### AI Translation
+
+Gale supports AI-powered translation for mod names, descriptions, and configuration entries. This feature uses any OpenAI-compatible API (e.g., OpenAI, DeepSeek, Moonshot, etc.).
+
+**How to use:**
+1. Go to **Settings** → **AI Translation**
+2. Enable the feature and configure your API endpoint
+3. Enter your API URL and API Key
+4. Adjust batch size if needed (default: 20 mods per request)
+5. Use the translate button in the toolbar or mod details page
+
+**Features:**
+- Batch translation (translate multiple mods in one API call)
+- Translation cache (persistent storage in local database)
+- Chinese/Japanese/Korean search support (search mods by translated names)
+- Toggle switch to show/hide translations
+- Auto-translation when browsing mod list
+- Config entry translation
 
 [...and more](https://github.com/Kesomannen/gale/wiki/Features)
 

--- a/src-tauri/migrations/08-translation-cache/down.sql
+++ b/src-tauri/migrations/08-translation-cache/down.sql
@@ -1,0 +1,2 @@
+DROP INDEX IF EXISTS idx_translation_cache_lookup;
+DROP TABLE IF EXISTS translation_cache;

--- a/src-tauri/migrations/08-translation-cache/up.sql
+++ b/src-tauri/migrations/08-translation-cache/up.sql
@@ -1,0 +1,12 @@
+CREATE TABLE translation_cache (
+    mod_uuid TEXT NOT NULL,
+    language TEXT NOT NULL,
+    original_name TEXT NOT NULL,
+    original_description TEXT,
+    translated_name TEXT NOT NULL,
+    translated_description TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (mod_uuid, language)
+);
+
+CREATE INDEX idx_translation_cache_lookup ON translation_cache(mod_uuid, language);

--- a/src-tauri/src/db/mod.rs
+++ b/src-tauri/src/db/mod.rs
@@ -127,7 +127,7 @@ pub struct SaveData {
 }
 
 impl Db {
-    fn conn(&self) -> MutexGuard<'_, rusqlite::Connection> {
+    pub fn conn(&self) -> MutexGuard<'_, rusqlite::Connection> {
         self.0.lock().unwrap()
     }
 
@@ -380,5 +380,66 @@ impl Db {
 
             Ok(())
         })
+    }
+
+    pub fn get_translation_cache(
+        &self,
+        mod_uuid: &str,
+        language: &str,
+        original_name: &str,
+        original_description: Option<&str>,
+    ) -> Result<Option<(String, Option<String>)>> {
+        let conn = self.conn();
+
+        let mut stmt = conn.prepare(
+            "SELECT translated_name, translated_description, original_name, original_description
+             FROM translation_cache
+             WHERE mod_uuid = ?1 AND language = ?2",
+        )?;
+
+        let result = stmt
+            .query_row(params![mod_uuid, language], |row| {
+                let cached_name: String = row.get(0)?;
+                let cached_desc: Option<String> = row.get(1)?;
+                let orig_name: String = row.get(2)?;
+                let orig_desc: Option<String> = row.get(3)?;
+
+                if orig_name == original_name && orig_desc.as_deref() == original_description {
+                    Ok(Some((cached_name, cached_desc)))
+                } else {
+                    Ok(None)
+                }
+            })
+            .optional()?;
+
+        Ok(result.flatten())
+    }
+
+    pub fn save_translation_cache(
+        &self,
+        mod_uuid: &str,
+        language: &str,
+        original_name: &str,
+        original_description: Option<&str>,
+        translated_name: &str,
+        translated_description: Option<&str>,
+    ) -> Result<()> {
+        let conn = self.conn();
+
+        conn.prepare(
+            "INSERT OR REPLACE INTO translation_cache
+             (mod_uuid, language, original_name, original_description, translated_name, translated_description)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+        )?
+        .execute(params![
+            mod_uuid,
+            language,
+            original_name,
+            original_description,
+            translated_name,
+            translated_description,
+        ])?;
+
+        Ok(())
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -19,6 +19,7 @@ mod prefs;
 mod profile;
 mod state;
 mod thunderstore;
+mod translation;
 mod util;
 
 fn setup(app: &mut App) -> Result<(), Box<dyn std::error::Error>> {
@@ -199,6 +200,9 @@ pub fn run() {
             config::commands::reset_config_file,
             config::commands::open_config_file,
             config::commands::delete_config_file,
+            translation::commands::translate_mods,
+            translation::commands::get_translation_prefs,
+            translation::commands::set_translation_prefs,
         ])
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_deep_link::init())

--- a/src-tauri/src/prefs/mod.rs
+++ b/src-tauri/src/prefs/mod.rs
@@ -16,6 +16,7 @@ use crate::{
     logger,
     profile::launch::LaunchMode,
     state::ManagerExt,
+    translation::TranslationPrefs,
     util::{
         self,
         error::IoResultExt,
@@ -189,6 +190,9 @@ pub struct Prefs {
     pub language: String,
 
     pub game_prefs: HashMap<String, GamePrefs>,
+
+    #[serde(default)]
+    pub translation: TranslationPrefs,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, Default)]
@@ -221,6 +225,8 @@ impl Default for Prefs {
             language: "en".to_string(),
 
             game_prefs: HashMap::new(),
+
+            translation: TranslationPrefs::default(),
         }
     }
 }
@@ -287,6 +293,7 @@ impl Prefs {
 
         self.fetch_mods_automatically = value.fetch_mods_automatically;
         self.pull_before_launch = value.pull_before_launch;
+        self.translation = value.translation;
 
         self.save(app.db()).context("failed save prefs")
     }

--- a/src-tauri/src/thunderstore/query.rs
+++ b/src-tauri/src/thunderstore/query.rs
@@ -12,6 +12,7 @@ use super::{
     BorrowedMod,
 };
 use crate::{
+    db::Db,
     profile::{LocalMod, Profile},
     state::ManagerExt,
     util,

--- a/src-tauri/src/translation/commands.rs
+++ b/src-tauri/src/translation/commands.rs
@@ -1,0 +1,86 @@
+use eyre::anyhow;
+use tauri::{command, AppHandle};
+
+use super::{TranslateRequest, TranslateResponse, TranslationPrefs, TranslationService};
+use crate::{logger, state::ManagerExt, util::cmd::Result};
+
+#[command]
+pub async fn translate_mods(
+    mods: Vec<TranslateRequest>,
+    target_language: String,
+    app: AppHandle,
+) -> Result<Vec<TranslateResponse>> {
+    let prefs = {
+        let prefs = app.lock_prefs();
+        prefs.translation.clone()
+    };
+
+    let db = app.db();
+    let mut results = Vec::new();
+    let mut uncached_mods = Vec::new();
+    let mut uncached_indices = Vec::new();
+
+    for (i, m) in mods.iter().enumerate() {
+        let cached = db.get_translation_cache(
+            &m.uuid,
+            &target_language,
+            &m.name,
+            m.description.as_deref(),
+        );
+
+        match cached {
+            Ok(Some((name, desc))) => {
+                results.push(Some(TranslateResponse { name, description: desc }));
+            }
+            _ => {
+                results.push(None);
+                uncached_mods.push(m.clone());
+                uncached_indices.push(i);
+            }
+        }
+    }
+
+    if uncached_mods.is_empty() {
+        return Ok(results.into_iter().flatten().collect());
+    }
+
+    let service = TranslationService::new();
+
+    match service
+        .translate_mods(&uncached_mods, &target_language, &prefs)
+        .await
+    {
+        Ok(translated) => {
+            for (idx, t) in uncached_indices.iter().zip(translated.iter()) {
+                results[*idx] = Some(t.clone());
+                let _ = db.save_translation_cache(
+                    &mods[*idx].uuid,
+                    &target_language,
+                    &mods[*idx].name,
+                    mods[*idx].description.as_deref(),
+                    &t.name,
+                    t.description.as_deref(),
+                );
+            }
+            Ok(results.into_iter().flatten().collect())
+        }
+        Err(err) => {
+            logger::log_webview_err("Translation failed", err, &app);
+            Err(anyhow!("Translation failed").into())
+        }
+    }
+}
+
+#[command]
+pub fn get_translation_prefs(app: AppHandle) -> TranslationPrefs {
+    let prefs = app.lock_prefs();
+    prefs.translation.clone()
+}
+
+#[command]
+pub fn set_translation_prefs(prefs: TranslationPrefs, app: AppHandle) -> Result<()> {
+    let mut current_prefs = app.lock_prefs();
+    current_prefs.translation = prefs;
+    app.db().save_prefs(&current_prefs)?;
+    Ok(())
+}

--- a/src-tauri/src/translation/mod.rs
+++ b/src-tauri/src/translation/mod.rs
@@ -1,0 +1,216 @@
+use std::{collections::HashMap, time::Duration};
+
+use eyre::{bail, Result};
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tracing::{debug, error, warn};
+
+pub mod commands;
+
+#[derive(Serialize, Deserialize, Clone, Debug, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslationPrefs {
+    pub enabled: bool,
+    pub api_url: String,
+    pub api_key: String,
+    pub model: String,
+    #[serde(default = "default_batch_size")]
+    pub batch_size: usize,
+}
+
+fn default_batch_size() -> usize {
+    20
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslateRequest {
+    pub uuid: String,
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug)]
+#[serde(rename_all = "camelCase")]
+pub struct TranslateResponse {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Serialize)]
+struct ChatMessage {
+    role: String,
+    content: String,
+}
+
+#[derive(Serialize)]
+struct ChatRequest {
+    model: String,
+    messages: Vec<ChatMessage>,
+    temperature: f32,
+}
+
+#[derive(Deserialize)]
+struct ChatResponse {
+    choices: Vec<ChatChoice>,
+}
+
+#[derive(Deserialize)]
+struct ChatChoice {
+    message: ChatMessageResponse,
+}
+
+#[derive(Deserialize)]
+struct ChatMessageResponse {
+    content: String,
+}
+
+pub struct TranslationService {
+    client: Client,
+}
+
+impl TranslationService {
+    pub fn new() -> Self {
+        Self {
+            client: Client::builder()
+                .timeout(Duration::from_secs(60))
+                .build()
+                .expect("failed to build HTTP client"),
+        }
+    }
+
+    pub async fn translate_mods(
+        &self,
+        mods: &[TranslateRequest],
+        target_language: &str,
+        prefs: &TranslationPrefs,
+    ) -> Result<Vec<TranslateResponse>> {
+        if prefs.api_url.is_empty() || prefs.api_key.is_empty() {
+            bail!("Translation API URL or API key is not configured");
+        }
+
+        let batch_size = if prefs.batch_size == 0 { 20 } else { prefs.batch_size };
+        let mut all_results = Vec::with_capacity(mods.len());
+
+        for chunk in mods.chunks(batch_size) {
+            let batch_results = self.translate_batch(chunk, target_language, prefs).await?;
+            all_results.extend(batch_results);
+        }
+
+        Ok(all_results)
+    }
+
+    async fn translate_batch(
+        &self,
+        mods: &[TranslateRequest],
+        target_language: &str,
+        prefs: &TranslationPrefs,
+    ) -> Result<Vec<TranslateResponse>> {
+        let prompt = self.build_batch_prompt(mods, target_language);
+
+        let request = ChatRequest {
+            model: prefs.model.clone(),
+            messages: vec![
+                ChatMessage {
+                    role: "system".to_string(),
+                    content: format!(
+                        "You are a professional translator for game mods. Translate the mod names and descriptions to {}. Keep translations natural and concise. Return ONLY a JSON array, no other text. Each element: {{\"uuid\": \"...\", \"name\": \"...\", \"description\": \"...\"}}",
+                        target_language
+                    ),
+                },
+                ChatMessage {
+                    role: "user".to_string(),
+                    content: prompt,
+                },
+            ],
+            temperature: 0.3,
+        };
+
+        let base = prefs.api_url.trim_end_matches('/');
+        let url = if base.ends_with("/chat/completions") {
+            base.to_string()
+        } else if base.ends_with("/v1") {
+            format!("{}/chat/completions", base)
+        } else {
+            format!("{}/v1/chat/completions", base)
+        };
+
+        debug!("Translating batch of {} mods -> {}", mods.len(), url);
+
+        let response = self
+            .client
+            .post(&url)
+            .header("Authorization", format!("Bearer {}", prefs.api_key))
+            .header("Content-Type", "application/json")
+            .json(&request)
+            .send()
+            .await?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            error!("Translation API error: {} - {}", status, body);
+            bail!("Translation API returned error: {}", status);
+        }
+
+        let chat_response: ChatResponse = response.json().await?;
+
+        let content = chat_response
+            .choices
+            .first()
+            .map(|c| c.message.content.clone())
+            .unwrap_or_default();
+
+        self.parse_batch_response(&content, mods)
+    }
+
+    fn build_batch_prompt(&self, mods: &[TranslateRequest], target_language: &str) -> String {
+        let mut lines = vec![format!("Translate these mods to {}:\n", target_language)];
+
+        for m in mods {
+            let desc = m.description.as_deref().unwrap_or("");
+            lines.push(format!("[uuid:{}]\nname:{}\ndescription:{}\n", m.uuid, m.name, desc));
+        }
+
+        lines.join("\n")
+    }
+
+    fn parse_batch_response(
+        &self,
+        content: &str,
+        originals: &[TranslateRequest],
+    ) -> Result<Vec<TranslateResponse>> {
+        let content = content.trim();
+
+        // Try to find JSON array in the response
+        if let Some(json_start) = content.find('[') {
+            if let Some(json_end) = content.rfind(']') {
+                let json_str = &content[json_start..=json_end];
+                if let Ok(parsed) = serde_json::from_str::<Vec<HashMap<String, String>>>(json_str) {
+                    let mut results = Vec::with_capacity(originals.len());
+                    for original in originals {
+                        let translated = parsed.iter().find(|m| m.get("uuid").map(|u| u.as_str()) == Some(&original.uuid));
+                        results.push(TranslateResponse {
+                            name: translated
+                                .and_then(|t| t.get("name").cloned())
+                                .unwrap_or_else(|| original.name.clone()),
+                            description: translated
+                                .and_then(|t| t.get("description").cloned())
+                                .or_else(|| original.description.clone()),
+                        });
+                    }
+                    return Ok(results);
+                }
+            }
+        }
+
+        warn!("Failed to parse translation response, falling back to originals. Response: {}", &content[..content.len().min(200)]);
+        Ok(originals
+            .iter()
+            .map(|m| TranslateResponse {
+                name: m.name.clone(),
+                description: m.description.clone(),
+            })
+            .collect())
+    }
+}

--- a/src/lib/api/index.ts
+++ b/src/lib/api/index.ts
@@ -6,5 +6,6 @@ export * as prefs from './prefs';
 export * as profile from './profile';
 export * as state from './state';
 export * as thunderstore from './thunderstore';
+export * as translation from './translation';
 
 export const isFlatpak = () => invoke<boolean>('is_flatpak');

--- a/src/lib/api/translation.ts
+++ b/src/lib/api/translation.ts
@@ -1,0 +1,10 @@
+import { invoke } from '$lib/invoke';
+import type { TranslateRequest, TranslateResponse, TranslationPrefs } from '$lib/types';
+
+export const translateMods = (mods: TranslateRequest[], targetLanguage: string) =>
+	invoke<TranslateResponse[]>('translate_mods', { mods, targetLanguage });
+
+export const getPrefs = () => invoke<TranslationPrefs>('get_translation_prefs');
+
+export const setPrefs = (prefs: TranslationPrefs) =>
+	invoke('set_translation_prefs', { prefs });

--- a/src/lib/components/config/ConfigEntryField.svelte
+++ b/src/lib/components/config/ConfigEntryField.svelte
@@ -12,6 +12,7 @@
 	import ColorConfig from './ColorConfig.svelte';
 	import { toSentenceCase } from '$lib/i18n';
 	import { m } from '$lib/paraglide/messages';
+	import translation from '$lib/state/translation.svelte';
 
 	type Props = {
 		entryId: ConfigEntryId;
@@ -56,23 +57,31 @@
 	let entry = $derived(entryId.entry);
 	let value = $derived(entry.value);
 	let typeName = $derived(getTypeName(value));
+
+	let translatedEntry = $derived(translation.getConfigTranslation(entryId.file.relativePath, entry.name));
+	let displayEntryName = $derived(
+		translation.showTranslation && translatedEntry ? translatedEntry.name : toSentenceCase(entry.name)
+	);
+	let displayEntryDesc = $derived(
+		translation.showTranslation && translatedEntry?.description ? translatedEntry.description : entry.description
+	);
 </script>
 
 <!-- odd:bg-[#1b2433] -->
 <div class="text-primary-300 odd:bg-primary-900/30 flex items-center px-3 py-1.5">
 	<div class="text-primary-300 w-[45%] min-w-52 shrink-0 cursor-auto truncate pr-2 text-left">
-		{toSentenceCase(entry.name)}
+		{displayEntryName}
 	</div>
 
 	<Info>
 		<h4>
-			<span class="text-lg font-semibold text-white">{entry.name}</span>
+			<span class="text-lg font-semibold text-white">{displayEntryName}</span>
 			<span class="text-primary-400 ml-1"> ({typeName})</span>
 		</h4>
 
-		{#if entry.description}
+		{#if displayEntryDesc}
 			<p class="mb-1 whitespace-pre-wrap">
-				{entry.description}
+				{displayEntryDesc}
 			</p>
 		{/if}
 

--- a/src/lib/components/config/ConfigFileEditor.svelte
+++ b/src/lib/components/config/ConfigFileEditor.svelte
@@ -10,6 +10,7 @@
 	import ConfigEntryField from './ConfigEntryField.svelte';
 	import { confirm } from '@tauri-apps/plugin-dialog';
 	import { page } from '$app/state';
+	import translation from '$lib/state/translation.svelte';
 
 	type Props = {
 		file: ConfigFileData;
@@ -22,10 +23,18 @@
 
 	let search = $derived(page.state.search ?? '');
 
-	// $effect(() => {
-	// 	file;
-	// 	search = '';
-	// });
+	// Translate config entries when file changes
+	let lastTranslatedFile = $state('');
+	$effect(() => {
+		const filePath = file.relativePath;
+		if (filePath && filePath !== lastTranslatedFile) {
+			lastTranslatedFile = filePath;
+			const allEntries = file.sections.flatMap((s) =>
+				s.entries.map((e) => ({ name: e.name, description: e.description }))
+			);
+			translation.translateConfigEntries(filePath, allEntries);
+		}
+	});
 
 	async function resetAll() {
 		const confirmed = await confirm(m.config_resetAllConfirm_message({ name: file.displayName }), {

--- a/src/lib/components/config/ConfigFileList.svelte
+++ b/src/lib/components/config/ConfigFileList.svelte
@@ -7,6 +7,7 @@
 	import profiles from '$lib/state/profile.svelte';
 	import { m } from '$lib/paraglide/messages';
 	import config from '$lib/state/config.svelte';
+	import translation from '$lib/state/translation.svelte';
 
 	let searchTerm = $state('');
 
@@ -36,15 +37,31 @@
 			sortedFiles = sortedFiles.filter((file) => {
 				let lowerSearch = searchTerm.toLowerCase().trim();
 
-				return (
-					file.relativePath.toLowerCase().includes(lowerSearch) ||
-					file.displayName?.toLowerCase().includes(lowerSearch)
-				);
+				// Check original name
+				const pathMatch = file.relativePath.toLowerCase().includes(lowerSearch);
+				const nameMatch = file.displayName?.toLowerCase().includes(lowerSearch);
+				if (pathMatch || nameMatch) return true;
+
+				// Check translation
+				if (translation.showTranslation && file.displayName) {
+					const translatedName = translation.getDisplayName('', file.displayName);
+					if (translatedName !== file.displayName && translatedName.toLowerCase().includes(lowerSearch)) {
+						return true;
+					}
+				}
+
+				return false;
 			});
 		}
 
 		sortedFiles.sort((a, b) => {
-			return (a.displayName ?? a.relativePath).localeCompare(b.displayName ?? b.relativePath);
+			const nameA = translation.showTranslation && a.displayName
+				? translation.getDisplayName('', a.displayName)
+				: (a.displayName ?? a.relativePath);
+			const nameB = translation.showTranslation && b.displayName
+				? translation.getDisplayName('', b.displayName)
+				: (b.displayName ?? b.relativePath);
+			return nameA.localeCompare(nameB);
 		});
 
 		return sortedFiles;

--- a/src/lib/components/config/ConfigFileListItem.svelte
+++ b/src/lib/components/config/ConfigFileListItem.svelte
@@ -5,6 +5,7 @@
 	import type { ConfigFile } from '$lib/types';
 	import Icon from '@iconify/svelte';
 	import { confirm } from '@tauri-apps/plugin-dialog';
+	import translation from '$lib/state/translation.svelte';
 
 	type Props = {
 		file: ConfigFile;
@@ -34,14 +35,18 @@
 			return { name: file.relativePath, disambiguator: null };
 		}
 
+		const shownName = translation.showTranslation
+			? translation.getDisplayName('', file.displayName)
+			: file.displayName;
+
 		if (duplicate) {
 			const firstFolder = file.relativePath.split('/')[0];
 			if (firstFolder !== file.displayName) {
-				return { name: file.displayName, disambiguator: firstFolder };
+				return { name: shownName, disambiguator: firstFolder };
 			}
 		}
 
-		return { name: file.displayName, disambiguator: null };
+		return { name: shownName, disambiguator: null };
 	});
 
 	async function deleteFile() {

--- a/src/lib/components/mod-list/ModDetails.svelte
+++ b/src/lib/components/mod-list/ModDetails.svelte
@@ -25,6 +25,7 @@
 	import config from '$lib/state/config.svelte';
 	import { goto } from '$app/navigation';
 	import InfoBox from '../ui/InfoBox.svelte';
+	import translation from '$lib/state/translation.svelte';
 
 	type Props = {
 		mod: Mod;
@@ -55,6 +56,11 @@
 
 	let readmePromise: Promise<string | null> | null = $state(null);
 
+	let displayName = $derived(translation.getDisplayName(mod.uuid, formatModName(mod.name)));
+	let displayDescription = $derived(translation.getDisplayDescription(mod.uuid, mod.description));
+	let isTranslatingThis = $derived(translation.isTranslating(mod.uuid));
+	let hasTranslation = $derived(!!translation.getTranslation(mod.uuid));
+
 	function formatReadme(readme: string | null) {
 		if (readme === null) return null;
 
@@ -67,6 +73,11 @@
 	$effect(() => {
 		readmePromise = getMarkdown(mod, 'readme').then(formatReadme);
 	});
+
+	async function handleTranslate() {
+		if (hasTranslation || isTranslatingThis) return;
+		await translation.translateMod(mod);
+	}
 </script>
 
 <div class="relative flex w-[40%] min-w-72 flex-col p-4 text-white">
@@ -91,7 +102,7 @@
 						mod.type === ModType.Remote && 'hover:underline'
 					]}
 					href={communityUrl(`${mod.author}/${mod.name}`)}
-					target="_blank">{formatModName(mod.name)}</svelte:element
+					target="_blank">{displayName}</svelte:element
 				>
 
 				{#if mod.author}
@@ -151,9 +162,9 @@
 			</div>
 		{/if}
 
-		{#if mod.description !== null}
+		{#if displayDescription !== null}
 			<p class="text-primary-300 mt-2 text-xl lg:hidden">
-				{mod.description}
+				{displayDescription}
 			</p>
 		{/if}
 
@@ -197,7 +208,7 @@
 			{onmouseenter}
 			{onclick}
 		>
-			<Icon {icon} class="mr-2 text-lg" />
+			<Icon {icon} class={["mr-2 text-lg", isTranslatingThis && "animate-spin"]} />
 			{label}
 		</button>
 	{/snippet}
@@ -220,6 +231,14 @@
 			'material-symbols:network-node',
 			`${m.modDetails_dependencies()} (${mod.dependencies.length})`,
 			() => (dependenciesOpen = true)
+		)}
+	{/if}
+
+	{#if translation.prefs?.enabled && translation.prefs?.apiUrl && translation.prefs?.apiKey}
+		{@render button(
+			isTranslatingThis ? 'mdi:loading' : hasTranslation ? 'mdi:check-circle' : 'mdi:translate',
+			isTranslatingThis ? 'Translating...' : hasTranslation ? 'Translated' : 'Translate',
+			handleTranslate
 		)}
 	{/if}
 

--- a/src/lib/components/mod-list/ModListItem.svelte
+++ b/src/lib/components/mod-list/ModListItem.svelte
@@ -12,6 +12,7 @@
 		shortenNum,
 		timeSince
 	} from '$lib/util';
+	import translation from '$lib/state/translation.svelte';
 
 	type Props = {
 		mod: Mod;
@@ -25,6 +26,9 @@
 	let { mod, selected: selected, locked, contextItems, onclick, oninstall }: Props = $props();
 
 	let loading = $state(false);
+
+	let displayName = $derived(translation.getDisplayName(mod.uuid, formatModName(mod.name)));
+	let displayDescription = $derived(translation.getDisplayDescription(mod.uuid, mod.description));
 </script>
 
 <ModItemWithContext {mod} {locked} {contextItems}>
@@ -45,7 +49,7 @@
 		<div class="shrink grow overflow-hidden text-left">
 			<div class="flex items-center gap-1 overflow-hidden">
 				<div class="shrink pr-1 text-lg font-medium text-white">
-					{formatModName(mod.name)}
+					{displayName}
 				</div>
 				{#if mod.isPinned}
 					<Icon class="text-primary-400 shrink-0" icon="mdi:pin" />
@@ -59,11 +63,14 @@
 				{#if isOutdated(mod)}
 					<Icon class="text-accent-500 shrink-0" icon="mdi:arrow-up-circle" />
 				{/if}
+				{#if translation.isTranslating(mod.uuid)}
+					<Icon class="text-primary-400 shrink-0 animate-spin" icon="mdi:loading" />
+				{/if}
 			</div>
 
-			{#if mod.description !== null}
+			{#if displayDescription !== null}
 				<div class="text-primary-300 line-clamp-1 text-sm text-ellipsis lg:line-clamp-2">
-					{mod.description}
+					{displayDescription}
 				</div>
 			{/if}
 

--- a/src/lib/components/mod-list/ProfileModListItemNoContext.svelte
+++ b/src/lib/components/mod-list/ProfileModListItemNoContext.svelte
@@ -5,6 +5,7 @@
 	import Icon from '@iconify/svelte';
 	import type { Snippet } from 'svelte';
 	import type { ClassValue } from 'clsx';
+	import translation from '$lib/state/translation.svelte';
 
 	type Props = {
 		mod: Mod;
@@ -16,6 +17,8 @@
 	};
 
 	let { mod, class: classProp, selected, onclick, leading, trailing }: Props = $props();
+
+	let displayName = $derived(translation.getDisplayName(mod.uuid, formatModName(mod.name)));
 </script>
 
 <!-- svelte-ignore a11y_click_events_have_key_events -->
@@ -39,7 +42,7 @@
 		<img src={modIconSrc(mod)} alt={mod.name} class="mr-3 size-10 rounded-sm" />
 
 		<div class={[mod.enabled ? 'text-white' : 'line-through', 'mr-2 shrink truncate font-medium']}>
-			{formatModName(mod.name)}
+			{displayName}
 		</div>
 
 		{#if mod.isPinned}

--- a/src/lib/components/prefs/TranslationPref.svelte
+++ b/src/lib/components/prefs/TranslationPref.svelte
@@ -1,0 +1,185 @@
+<script lang="ts">
+	import Info from '$lib/components/ui/Info.svelte';
+	import Label from '$lib/components/ui/Label.svelte';
+	import translation from '$lib/state/translation.svelte';
+	import Icon from '@iconify/svelte';
+	import { confirm } from '@tauri-apps/plugin-dialog';
+
+	let prefs = $derived(translation.prefs);
+	let enabled = $derived(prefs?.enabled ?? false);
+	let apiUrl = $derived(prefs?.apiUrl ?? '');
+	let apiKey = $derived(prefs?.apiKey ?? '');
+	let model = $derived(prefs?.model ?? 'gpt-4o-mini');
+
+	let testResult: { ok: boolean; message: string } | null = $state(null);
+	let testing = $state(false);
+	let showApiKey = $state(false);
+
+	async function toggleEnabled() {
+		if (!prefs) return;
+
+		if (prefs.enabled) {
+			const confirmed = await confirm('Disable AI translation?');
+			if (!confirmed) return;
+		}
+
+		translation.prefs = { ...prefs, enabled: !prefs.enabled };
+		await translation.savePrefs();
+	}
+
+	async function updateApiUrl(value: string) {
+		if (!prefs) return;
+		translation.prefs = { ...prefs, apiUrl: value };
+		await translation.savePrefs();
+	}
+
+	async function updateApiKey(value: string) {
+		if (!prefs) return;
+		translation.prefs = { ...prefs, apiKey: value };
+		await translation.savePrefs();
+	}
+
+	async function updateModel(value: string) {
+		if (!prefs) return;
+		translation.prefs = { ...prefs, model: value };
+		await translation.savePrefs();
+	}
+
+	async function updateBatchSize(value: string) {
+		if (!prefs) return;
+		const num = parseInt(value, 10);
+		if (isNaN(num) || num < 1) return;
+		translation.prefs = { ...prefs, batchSize: num };
+		await translation.savePrefs();
+	}
+
+	async function handleTest() {
+		testing = true;
+		testResult = null;
+		try {
+			testResult = await translation.testConnection();
+		} finally {
+			testing = false;
+		}
+	}
+</script>
+
+<div class="my-2 rounded-lg border border-primary-700 p-4">
+	<div class="flex items-center justify-between">
+		<div class="flex items-center gap-2">
+			<Icon icon="mdi:translate" class="text-primary-300 text-xl" />
+			<Label>AI Translation</Label>
+		</div>
+
+		<button
+			class="relative inline-flex h-6 w-11 items-center rounded-full transition-colors"
+			class:bg-primary-600={enabled}
+			class:bg-primary-800={!enabled}
+			onclick={toggleEnabled}
+			aria-label="Toggle AI translation"
+		>
+			<span
+				class="inline-block h-4 w-4 transform rounded-full bg-white transition-transform"
+				class:translate-x-6={enabled}
+				class:translate-x-1={!enabled}
+			></span>
+		</button>
+	</div>
+
+	{#if enabled}
+		<div class="mt-4 space-y-3">
+			<div>
+				<Label>API URL</Label>
+				<input
+					type="text"
+					value={apiUrl}
+					placeholder="https://api.openai.com"
+					class="bg-primary-800 border-primary-700 text-primary-100 mt-1 w-full rounded-lg border px-3 py-2 text-sm"
+					onchange={(e) => updateApiUrl(e.currentTarget.value)}
+				/>
+				<p class="text-primary-400 mt-1 text-xs">Base URL or full endpoint. Auto-appends /v1/chat/completions if needed.</p>
+			</div>
+
+			<div>
+				<Label>API Key</Label>
+				<div class="relative mt-1">
+					<input
+						type={showApiKey ? 'text' : 'password'}
+						value={apiKey}
+						placeholder="sk-..."
+						class="bg-primary-800 border-primary-700 text-primary-100 w-full rounded-lg border px-3 py-2 pr-10 text-sm"
+						onchange={(e) => updateApiKey(e.currentTarget.value)}
+					/>
+					<button
+						type="button"
+						class="text-primary-400 hover:text-primary-200 absolute right-2 top-1/2 -translate-y-1/2"
+						onclick={() => (showApiKey = !showApiKey)}
+						aria-label={showApiKey ? 'Hide API key' : 'Show API key'}
+					>
+						<Icon icon={showApiKey ? 'mdi:eye-off' : 'mdi:eye'} />
+					</button>
+				</div>
+			</div>
+
+			<div>
+				<Label>Model</Label>
+				<input
+					type="text"
+					value={model}
+					placeholder="gpt-4o-mini"
+					class="bg-primary-800 border-primary-700 text-primary-100 mt-1 w-full rounded-lg border px-3 py-2 text-sm"
+					onchange={(e) => updateModel(e.currentTarget.value)}
+				/>
+			</div>
+
+			<div>
+				<Label>Batch Size</Label>
+				<input
+					type="number"
+					value={prefs?.batchSize ?? 20}
+					min="1"
+					max="50"
+					placeholder="20"
+					class="bg-primary-800 border-primary-700 text-primary-100 mt-1 w-full rounded-lg border px-3 py-2 text-sm"
+					onchange={(e) => updateBatchSize(e.currentTarget.value)}
+				/>
+				<p class="text-primary-400 mt-1 text-xs">Number of mods to translate per request (1-50)</p>
+			</div>
+
+			<button
+				class="bg-accent-600 hover:bg-accent-500 flex items-center gap-2 rounded-md px-4 py-2 text-sm text-white disabled:opacity-50"
+				onclick={handleTest}
+				disabled={testing || !apiUrl || !apiKey}
+			>
+				{#if testing}
+					<Icon icon="mdi:loading" class="animate-spin" />
+					Testing...
+				{:else}
+					<Icon icon="mdi:connection" />
+					Test Connection
+				{/if}
+			</button>
+
+			{#if testResult}
+				<div
+					class="flex items-center gap-2 rounded-md p-2 text-sm"
+					class:bg-green-900={testResult.ok}
+					class:text-green-300={testResult.ok}
+					class:bg-red-900={!testResult.ok}
+					class:text-red-300={!testResult.ok}
+				>
+					<Icon icon={testResult.ok ? 'mdi:check-circle' : 'mdi:alert-circle'} />
+					{testResult.message}
+				</div>
+			{/if}
+
+			{#if translation.error}
+				<div class="text-sm text-red-400">{translation.error}</div>
+			{/if}
+
+			<Info>
+				Configure an OpenAI-compatible API endpoint for translating mod names and descriptions.
+			</Info>
+		</div>
+	{/if}
+</div>

--- a/src/lib/components/toolbar/Toolbar.svelte
+++ b/src/lib/components/toolbar/Toolbar.svelte
@@ -17,6 +17,7 @@
 	import ContextMenuContent from '../ui/ContextMenuContent.svelte';
 	import type { ContextItem } from '$lib/types';
 	import { PersistedState } from 'runed';
+	import translation from '$lib/state/translation.svelte';
 
 	type Mode = 'vanilla' | 'modded';
 
@@ -54,6 +55,10 @@
 	});
 
 	const activeGameName = $derived(games.active?.name ?? m.unknown());
+
+	let isTranslationEnabled = $derived(
+		translation.prefs?.enabled && translation.prefs?.apiKey && translation.prefs?.apiUrl
+	);
 
 	async function launchGame() {
 		if (await api.profile.install.hasPendingInstallations()) {
@@ -115,6 +120,32 @@
 	<Syncer />
 	<InstallPopover />
 	<Updater />
+
+	{#if isTranslationEnabled}
+		<div class="border-primary-600 flex shrink-0 items-center gap-1 border-l px-2">
+			<button
+				class="text-primary-300 hover:text-primary-100 p-1"
+				onclick={() => translation.requestTranslateVisible()}
+				title="Translate visible mods"
+			>
+				<Icon icon="mdi:translate" class="text-xl" />
+			</button>
+
+			<button
+				class="relative inline-flex h-5 w-9 items-center rounded-full transition-colors"
+				class:bg-primary-500={translation.showTranslation}
+				class:bg-primary-700={!translation.showTranslation}
+				onclick={() => (translation.showTranslation = !translation.showTranslation)}
+				title={translation.showTranslation ? 'Showing translations' : 'Showing originals'}
+			>
+				<span
+					class="inline-block h-3.5 w-3.5 transform rounded-full bg-white transition-transform"
+					class:translate-x-4.5={translation.showTranslation}
+					class:translate-x-0.5={!translation.showTranslation}
+				></span>
+			</button>
+		</div>
+	{/if}
 </div>
 
 <Dialog

--- a/src/lib/state/translation.svelte.ts
+++ b/src/lib/state/translation.svelte.ts
@@ -1,0 +1,235 @@
+import * as api from '$lib/api';
+import type { Mod, TranslateRequest, TranslateResponse, TranslationPrefs } from '$lib/types';
+import { getLocale } from '$lib/paraglide/runtime';
+
+class TranslationState {
+	prefs: TranslationPrefs | null = $state(null);
+	cache: Record<string, TranslateResponse> = $state({});
+	nameLookup: Record<string, string> = $state({});
+	configCache: Record<string, TranslateResponse> = $state({});
+	translating: Record<string, boolean> = $state({});
+	error: string | null = $state(null);
+	translateRequest: number = $state(0);
+	showTranslation: boolean = $state(true);
+
+	constructor() {
+		this.loadPrefs();
+	}
+
+	async loadPrefs() {
+		try {
+			this.prefs = await api.translation.getPrefs();
+		} catch (err) {
+			console.error('Failed to load translation prefs:', err);
+			this.prefs = { enabled: false, apiUrl: '', apiKey: '', model: 'gpt-4o-mini', batchSize: 20 };
+		}
+	}
+
+	async savePrefs() {
+		if (!this.prefs) return;
+		try {
+			await api.translation.setPrefs(this.prefs);
+		} catch (err) {
+			console.error('Failed to save translation prefs:', err);
+		}
+	}
+
+	requestTranslateVisible() {
+		this.translateRequest++;
+	}
+
+	getTargetLanguage(): string {
+		const locale = getLocale();
+		const languageMap: Record<string, string> = {
+			en: 'English',
+			zh: 'Simplified Chinese',
+			'zh-CN': 'Simplified Chinese',
+			'zh-TW': 'Traditional Chinese',
+			ja: 'Japanese',
+			ko: 'Korean',
+			es: 'Spanish',
+			fr: 'French',
+			de: 'German',
+			ru: 'Russian',
+			pt: 'Portuguese',
+			'pt-BR': 'Brazilian Portuguese',
+			it: 'Italian',
+			nl: 'Dutch',
+			pl: 'Polish',
+			tr: 'Turkish',
+			th: 'Thai',
+			vi: 'Vietnamese'
+		};
+		const normalized = locale.split('-')[0].toLowerCase();
+		return languageMap[locale] || languageMap[normalized] || 'English';
+	}
+
+	isTranslating(key: string): boolean {
+		return !!this.translating[key];
+	}
+
+	getTranslation(uuid: string): TranslateResponse | null {
+		return this.cache[uuid] || null;
+	}
+
+	getDisplayName(uuid: string, originalName: string): string {
+		if (!this.showTranslation) return originalName;
+		if (uuid) {
+			const t = this.cache[uuid];
+			if (t) return t.name;
+		}
+		const cached = this.cache[`_name_${originalName}`];
+		if (cached) return cached.name;
+		return originalName;
+	}
+
+	getDisplayDescription(uuid: string, originalDesc: string | null): string | null {
+		if (!this.showTranslation) return originalDesc;
+		if (!uuid) return originalDesc;
+		const t = this.cache[uuid];
+		return t?.description ?? originalDesc;
+	}
+
+	async translateMod(mod: Mod): Promise<TranslateResponse | null> {
+		if (!this.prefs?.apiUrl || !this.prefs?.apiKey) return null;
+		if (this.cache[mod.uuid]) return this.cache[mod.uuid];
+		if (this.translating[mod.uuid]) return null;
+
+		this.translating = { ...this.translating, [mod.uuid]: true };
+		this.error = null;
+
+		try {
+			const request: TranslateRequest = { uuid: mod.uuid, name: mod.name, description: mod.description };
+			const results = await api.translation.translateMods([request], this.getTargetLanguage());
+			if (results.length > 0) {
+				const result = results[0];
+				this.cache = { ...this.cache, [mod.uuid]: result };
+				this.nameLookup = { ...this.nameLookup, [mod.name.toLowerCase()]: mod.uuid };
+				return result;
+			}
+		} catch (err) {
+			console.error('Translation failed:', err);
+			this.error = err instanceof Error ? err.message : 'Translation failed';
+		} finally {
+			const { [mod.uuid]: _, ...rest } = this.translating;
+			this.translating = rest;
+		}
+		return null;
+	}
+
+	async translateMods(mods: Mod[]): Promise<void> {
+		if (!this.prefs?.apiUrl || !this.prefs?.apiKey) return;
+
+		const toTranslate = mods.filter((mod) => !this.cache[mod.uuid] && !this.translating[mod.uuid]);
+		if (toTranslate.length === 0) return;
+
+		this.error = null;
+		const newTranslating = { ...this.translating };
+		toTranslate.forEach((m) => (newTranslating[m.uuid] = true));
+		this.translating = newTranslating;
+
+		try {
+			const requests: TranslateRequest[] = toTranslate.map((mod) => ({
+				uuid: mod.uuid, name: mod.name, description: mod.description
+			}));
+			const results = await api.translation.translateMods(requests, this.getTargetLanguage());
+
+			const newCache = { ...this.cache };
+			const newNameLookup = { ...this.nameLookup };
+			toTranslate.forEach((mod, i) => {
+				if (i < results.length) {
+					newCache[mod.uuid] = results[i];
+					newNameLookup[mod.name.toLowerCase()] = mod.uuid;
+				}
+			});
+			this.cache = newCache;
+			this.nameLookup = newNameLookup;
+		} catch (err) {
+			console.error('Translation failed:', err);
+			this.error = err instanceof Error ? err.message : 'Translation failed';
+		} finally {
+			const newTranslating = { ...this.translating };
+			toTranslate.forEach((m) => delete newTranslating[m.uuid]);
+			this.translating = newTranslating;
+		}
+	}
+
+	async translateNames(names: string[]): Promise<void> {
+		await this.translateGenericBatch(
+			names.map((name) => ({ key: `_name_${name}`, name, description: null as string | null })),
+			this.cache,
+			(newEntries) => { this.cache = { ...this.cache, ...newEntries }; }
+		);
+	}
+
+	async testConnection(): Promise<{ ok: boolean; message: string }> {
+		if (!this.prefs?.apiUrl || !this.prefs?.apiKey) {
+			return { ok: false, message: 'Please fill in API URL and API Key' };
+		}
+		try {
+			const request: TranslateRequest = { uuid: 'test', name: 'Test Mod', description: 'A test mod for verification' };
+			const results = await api.translation.translateMods([request], 'Simplified Chinese');
+			if (results.length > 0) {
+				return { ok: true, message: `Success! Translated to: ${results[0].name}` };
+			}
+			return { ok: false, message: 'No response from API' };
+		} catch (err) {
+			return { ok: false, message: err instanceof Error ? err.message : 'Connection failed' };
+		}
+	}
+
+	clearCache(): void {
+		this.cache = {};
+		this.nameLookup = {};
+		this.configCache = {};
+		this.translating = {};
+		this.error = null;
+	}
+
+	getConfigTranslation(filePath: string, entryName: string): TranslateResponse | null {
+		return this.configCache[`${filePath}::${entryName}`] || null;
+	}
+
+	async translateConfigEntries(
+		filePath: string,
+		entries: { name: string; description: string | null }[]
+	): Promise<void> {
+		await this.translateGenericBatch(
+			entries.map((e) => ({ key: `${filePath}::${e.name}`, name: e.name, description: e.description })),
+			this.configCache,
+			(newEntries) => { this.configCache = { ...this.configCache, ...newEntries }; }
+		);
+	}
+
+	private async translateGenericBatch(
+		items: { key: string; name: string; description: string | null }[],
+		targetCache: Record<string, TranslateResponse>,
+		apply: (entries: Record<string, TranslateResponse>) => void
+	): Promise<void> {
+		if (!this.prefs?.apiUrl || !this.prefs?.apiKey || items.length === 0) return;
+
+		const toTranslate = items.filter((item) => !targetCache[item.key]);
+		if (toTranslate.length === 0) return;
+
+		try {
+			const requests: TranslateRequest[] = toTranslate.map((item) => ({
+				uuid: item.key, name: item.name, description: item.description
+			}));
+			const results = await api.translation.translateMods(requests, this.getTargetLanguage());
+
+			const newEntries: Record<string, TranslateResponse> = {};
+			toTranslate.forEach((item, i) => {
+				if (i < results.length) {
+					newEntries[item.key] = results[i];
+				}
+			});
+			apply(newEntries);
+		} catch (err) {
+			console.error('Translation failed:', err);
+		}
+	}
+}
+
+const translation = new TranslationState();
+
+export default translation;

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -312,6 +312,7 @@ export type Prefs = {
 	zoomFactor: number;
 	language: string;
 	gamePrefs: Map<string, GamePrefs>;
+	translation: TranslationPrefs;
 };
 
 export type GamePrefs = {
@@ -358,3 +359,22 @@ export type ListItem =
 			type: 'folder';
 			folder: Folder;
 	  };
+
+export type TranslationPrefs = {
+	enabled: boolean;
+	apiUrl: string;
+	apiKey: string;
+	model: string;
+	batchSize: number;
+};
+
+export type TranslateRequest = {
+	uuid: string;
+	name: string;
+	description: string | null;
+};
+
+export type TranslateResponse = {
+	name: string;
+	description: string | null;
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -30,6 +30,7 @@
 	import HelpCard from '$lib/components/ui/HelpCard.svelte';
 	import config from '$lib/state/config.svelte';
 	import { goto } from '$app/navigation';
+	import translation from '$lib/state/translation.svelte';
 
 	const sortOptions: SortBy[] = [
 		'custom',
@@ -197,6 +198,12 @@
 		profiles.active;
 		profileQuery.current;
 		refresh();
+	});
+
+	$effect(() => {
+		if (mods.length > 0 && translation.prefs?.apiKey && translation.prefs?.apiUrl) {
+			translation.translateMods(mods);
+		}
 	});
 
 	let reorderable = $derived(

--- a/src/routes/browse/+page.svelte
+++ b/src/routes/browse/+page.svelte
@@ -15,6 +15,7 @@
 	import profiles from '$lib/state/profile.svelte';
 	import { modQuery } from '$lib/state/misc.svelte';
 	import { m } from '$lib/paraglide/messages';
+	import translation from '$lib/state/translation.svelte';
 
 	const sortOptions: SortBy[] = ['lastUpdated', 'newest', 'rating', 'downloads'];
 	const contextItems = [...defaultContextItems];
@@ -43,13 +44,22 @@
 	let hasRefreshed = $state(false);
 	let refreshing = false;
 
+	function isNonAscii(str: string): boolean {
+		return /[^\x00-\x7F]/.test(str);
+	}
+
 	async function refresh() {
 		if (refreshing) return;
 		refreshing = true;
 
-		mods = await api.thunderstore.query({ ...modQuery.current, maxCount });
+		// If search contains non-ASCII (e.g. Chinese, Japanese, etc.), filter on frontend
+		const queryForBackend = { ...modQuery.current };
+		if (queryForBackend.searchTerm && isNonAscii(queryForBackend.searchTerm)) {
+			queryForBackend.searchTerm = '';
+		}
+
+		mods = await api.thunderstore.query({ ...queryForBackend, maxCount });
 		if (selectedMod) {
-			// isInstalled might have changed
 			selectedMod = mods.find((mod) => mod.uuid === selectedMod!.uuid) ?? null;
 		}
 
@@ -85,6 +95,48 @@
 		}
 	});
 
+	let lastTranslateRequest = $state(0);
+
+	$effect(() => {
+		if (translation.translateRequest > lastTranslateRequest) {
+			lastTranslateRequest = translation.translateRequest;
+			if (mods.length > 0) {
+				translation.translateMods(mods);
+			}
+		}
+	});
+
+	let lastAutoTranslatedCount = $state(0);
+
+	$effect(() => {
+		if (mods.length > 0 && translation.prefs?.enabled && translation.prefs?.apiKey && translation.prefs?.apiUrl && mods.length !== lastAutoTranslatedCount) {
+			lastAutoTranslatedCount = mods.length;
+			translation.translateMods(mods);
+		}
+	});
+
+	let displayMods = $derived.by(() => {
+		const searchTerm = modQuery.current.searchTerm?.toLowerCase().trim();
+		if (!searchTerm) return mods;
+
+		return mods.filter((mod) => {
+			// Check original name/description
+			const nameMatch = mod.name.toLowerCase().replace(/_/g, ' ').includes(searchTerm);
+			const descMatch = mod.description?.toLowerCase().includes(searchTerm);
+			if (nameMatch || descMatch) return true;
+
+			// Check translation
+			const translated = translation.getTranslation(mod.uuid);
+			if (translated) {
+				const transNameMatch = translated.name.toLowerCase().includes(searchTerm);
+				const transDescMatch = translated.description?.toLowerCase().includes(searchTerm);
+				if (transNameMatch || transDescMatch) return true;
+			}
+
+			return false;
+		});
+	});
+
 	let locked = $derived(profiles.activeLocked);
 </script>
 
@@ -97,7 +149,7 @@
 		{/if}
 
 		<ModList
-			{mods}
+			mods={displayMods}
 			queryArgs={modQuery.current}
 			bind:this={modList}
 			bind:maxCount

--- a/src/routes/config/+page.svelte
+++ b/src/routes/config/+page.svelte
@@ -13,12 +13,28 @@
 	import config from '$lib/state/config.svelte';
 	import { untrack } from 'svelte';
 	import HelpCard from '$lib/components/ui/HelpCard.svelte';
+	import translation from '$lib/state/translation.svelte';
 
 	const selectedFile = $derived(config.selectedFile);
 
 	$effect(() => {
 		profiles.activeId;
 		untrack(() => config.refresh());
+	});
+
+	// Translate config file names when files are loaded
+	let lastTranslatedCount = $state(0);
+	$effect(() => {
+		const files = config.files;
+		if (files.length > 0 && files.length !== lastTranslatedCount) {
+			lastTranslatedCount = files.length;
+			const namesToTranslate = files
+				.filter(f => f.displayName && !translation.getTranslation(f.displayName))
+				.map(f => f.displayName!);
+			if (namesToTranslate.length > 0) {
+				translation.translateNames(namesToTranslate);
+			}
+		}
 	});
 </script>
 

--- a/src/routes/prefs/+page.svelte
+++ b/src/routes/prefs/+page.svelte
@@ -9,6 +9,7 @@
 	import LargeHeading from '$lib/components/prefs/LargeHeading.svelte';
 	import SmallHeading from '$lib/components/prefs/SmallHeading.svelte';
 	import PlatformPref from '$lib/components/prefs/PlatformPref.svelte';
+	import TranslationPref from '$lib/components/prefs/TranslationPref.svelte';
 
 	import type { Prefs, GamePrefs, Platform } from '$lib/types';
 	import { onMount } from 'svelte';
@@ -144,6 +145,9 @@
 		>
 			{m.prefs_miscellaneous_pullBeforeLaunch_content()}
 		</TogglePref>
+
+		<SmallHeading>AI Translation</SmallHeading>
+		<TranslationPref />
 
 		<LargeHeading>
 			{m.prefs_gameSettings_title({ game: games.active?.name ?? m.unknown() })}


### PR DESCRIPTION
…fig entries

- Add translation module (Rust backend) with OpenAI-compatible API support
- Add translation state management (Svelte frontend) with caching
- Add batch translation support with configurable batch size
- Add translation cache with persistent storage in SQLite database
- Add auto-translation when browsing mod list
- Add manual translation button in mod details page
- Add toggle switch to show/hide translations
- Add config entry translation support
- Add search support for translated names (Chinese, Japanese, Korean, etc.)