### PR TITLE
Update hexium URLs to definitive domain

### DIFF
--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -30,7 +30,7 @@
 					"url": "https://thunderstore.io/api/*"
 				},
 				{
-					"url": "https://mods.valtools.org/api/*"
+					"url": "https://hexium.gg/api/*"
 				},
 				{
 					"url": "https://raw.githubusercontent.com/Kesomannen/gale/master/*"

--- a/src-tauri/src/thunderstore/backend.rs
+++ b/src-tauri/src/thunderstore/backend.rs
@@ -34,10 +34,10 @@ impl Backend {
             )),
             Backend::Hexium => {
                 if game.slug == "valheim" {
-                    Some(
-                        "https://mods.valtools.org/c/valheim/api/v1/package-listing-index/"
-                            .to_string(),
-                    )
+                    Some(format!(
+                        "https://{}.hexium.gg/api/v1/package-listing-index/",
+                        game.slug,
+                    ))
                 } else {
                     None
                 }
@@ -55,7 +55,7 @@ impl Backend {
                 cache
             ),
             Backend::Hexium => format!(
-                "https://mods.valtools.org/api/experimental/package/{}/{}/{}/{}/",
+                "https://hexium.gg/api/experimental/package/{}/{}/{}/{}/",
                 ident.owner(),
                 ident.name(),
                 ident.version(),
@@ -69,7 +69,7 @@ impl Backend {
             Backend::Thunderstore => {
                 format!("https://thunderstore.io/c/{}/p/{}/", game.slug, owner)
             }
-            Backend::Hexium => format!("https://mods.valtools.org/teams/{}", owner),
+            Backend::Hexium => format!("https://{}.hexium.gg/teams/{}", game.slug, owner),
         }
     }
 
@@ -84,7 +84,8 @@ impl Backend {
                 )
             }
             Backend::Hexium => format!(
-                "https://mods.valtools.org/mods/1/{}/{}",
+                "https://{}.hexium.gg/mods/{}/{}",
+                game.slug,
                 package.name(),
                 package.name()
             ),
@@ -100,7 +101,7 @@ impl Backend {
                 version.version()
             ),
             Backend::Hexium => format!(
-                "https://mods.valtools.org/uploads/{}/{}/{}.zip",
+                "https://cdn.hexium.gg/uploads/{}/{}/{}.zip",
                 version.owner(),
                 version.name(),
                 version.version()
@@ -114,7 +115,7 @@ impl Backend {
                 format!("https://thunderstore.io/api/experimental/legacyprofile/get/{key}/")
             }
             Backend::Hexium => {
-                format!("https://mods.valtools.org/api/experimental/legacyprofile/get/{key}/")
+                format!("https://hexium.gg/api/experimental/legacyprofile/get/{key}/")
             }
         }
     }
@@ -124,14 +125,14 @@ impl Backend {
             Backend::Thunderstore => {
                 "https://thunderstore.io/api/experimental/legacyprofile/create/"
             }
-            Backend::Hexium => "https://mods.valtools.org/api/experimental/legacyprofile/create/",
+            Backend::Hexium => "https://hexium.gg/api/experimental/legacyprofile/create/",
         }
     }
 
     pub fn modpack_upload_baseurl(self) -> &'static str {
         match self {
             Backend::Thunderstore => "https://thunderstore.io/api/experimental",
-            Backend::Hexium => "https://mods.valtools.org/api/experimental",
+            Backend::Hexium => "https://hexium.gg/api/experimental",
         }
     }
 }

--- a/src/lib/components/dialogs/ApiKeyDialog.svelte
+++ b/src/lib/components/dialogs/ApiKeyDialog.svelte
@@ -14,7 +14,7 @@
 	let helpUrl = $derived(
 		apiKeyDialog.backend === Backend.Thunderstore
 			? 'https://github.com/Kesomannen/gale/wiki/Getting-a-Thunderstore-API-token'
-			: 'https://mods.valtools.org/faq#api-token'
+			: 'https://hexium.gg/faq#api-token'
 	);
 
 	async function submit() {

--- a/src/lib/components/ui/ModCard.svelte
+++ b/src/lib/components/ui/ModCard.svelte
@@ -22,12 +22,12 @@
 
 	let authorLink = $derived(
 		backend === Backend.Hexium
-			? `https://mods.valtools.org/teams/${author}`
+			? `https://${games.active?.slug}.hexium.gg/teams/${author}`
 			: `https://thunderstore.io/c/${games.active?.slug}/p/${author}/`
 	);
 	let modLink = $derived(
 		backend === Backend.Hexium
-			? `https://mods.valtools.org/mods/1/${author}/${name}`
+			? `https://${games.active?.slug}.hexium.gg/mods/${author}/${name}`
 			: `https://thunderstore.io/c/${games.active?.slug}/p/${author}/${name}/`
 	);
 	let iconUrl = $derived(

--- a/src/lib/state/game.svelte.ts
+++ b/src/lib/state/game.svelte.ts
@@ -58,7 +58,7 @@ class GamesState {
 				case Backends.Hexium:
 					backends = [];
 				case Backends.All:
-					backends.push('https://mods.valtools.org/api');
+					backends.push('https://hexium.gg/api');
 			}
 		}
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -66,7 +66,7 @@ export function isOutdated(mod: Mod): boolean {
 
 export function communityUrl(backend: Backend, author: string, mod?: string) {
 	if (backend === Backend.Hexium) {
-		return `https://mods.valtools.org/${mod === undefined ? `teams/${author}` : `mods/1/${author}/${mod}`}`;
+		return `https://${games.active?.slug}.hexium.gg/${mod === undefined ? `teams/${author}` : `mods/${author}/${mod}`}`;
 	} else {
 		return `https://thunderstore.io/c/${games.active?.slug}/p/${author}${mod && `/${mod}`}/`;
 	}
@@ -97,7 +97,7 @@ export function thunderstoreIconUrl(fullName: string) {
 }
 
 export function hexiumIconUrl(pkg: string, name: string) {
-	return `https://mods.valtools.org/uploads/${pkg}/${name}/icon.png`;
+	return `https://cdn.hexium.gg/uploads/${pkg}/${name}/icon.png`;
 }
 
 export function capitalize(str: string): string {


### PR DESCRIPTION
Using `hexium.gg` now. The old urls still work, but changing this before release would be optimal :-)