### PR TITLE
Fix touchpad not being able to open the info screen

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
 	},
 	"type": "module",
 	"dependencies": {
+		"@dnd-kit/dom": "^0.4.0",
 		"@dnd-kit/svelte": "^0.4.0",
 		"@tauri-apps/api": "^2.11.0",
 		"@tauri-apps/plugin-clipboard-manager": "^2.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/dom':
+        specifier: ^0.4.0
+        version: 0.4.0
       '@dnd-kit/svelte':
         specifier: ^0.4.0
         version: 0.4.0(svelte@5.56.2)

--- a/src/lib/components/profile/ReorderableList.svelte
+++ b/src/lib/components/profile/ReorderableList.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { DragDropProvider, DragOverlay } from '@dnd-kit/svelte';
 	import { isSortable } from '@dnd-kit/svelte/sortable';
+	import { PointerActivationConstraints, PointerSensor } from '@dnd-kit/dom';
 	import ReorderableMod from './ReorderableMod.svelte';
 	import type { ListItem, Mod } from '$lib/types';
 	import type { Snippet } from 'svelte';
@@ -45,7 +46,17 @@
 	}
 </script>
 
-<DragDropProvider {onDragOver}>
+<DragDropProvider
+	{onDragOver}
+	sensors={(defaults) => [
+		...defaults.filter((sensor) => sensor !== PointerSensor),
+		PointerSensor.configure({
+			activationConstraints: [
+				new PointerActivationConstraints.Delay({ value: 250, tolerance: 6 })
+			]
+		})
+	]}
+>
 	<VirtualList {items} rowId={(item) => itemId(item)} itemHeight={58}>
 		{#snippet children({ item, index })}
 			{@const hovered = item === hovering}

--- a/src/lib/components/profile/ReorderableList.svelte
+++ b/src/lib/components/profile/ReorderableList.svelte
@@ -52,7 +52,7 @@
 		...defaults.filter((sensor) => sensor !== PointerSensor),
 		PointerSensor.configure({
 			activationConstraints: [
-				new PointerActivationConstraints.Delay({ value: 250, tolerance: 6 })
+				new PointerActivationConstraints.Distance({ value: 6 })
 			]
 		})
 	]}

--- a/src/lib/components/profile/ReorderableMod.svelte
+++ b/src/lib/components/profile/ReorderableMod.svelte
@@ -33,6 +33,6 @@
 	});
 </script>
 
-<div {@attach sortable.attach} id={mod.uuid} class={[sortable.isDragging && 'opacity-40']}>
+<div {@attach sortable.attach} id={mod.uuid} class={['select-none', sortable.isDragging && 'opacity-40']}>
 	{@render children?.()}
 </div>


### PR DESCRIPTION
## Issue

Mouse input:
<img width="1821" height="930" alt="IssueShowcase-mouse" src="https://github.com/user-attachments/assets/84c92cc5-149b-437b-a57c-e5ba5f47f756" />

Touchpad input:
<img width="1821" height="930" alt="IssueShowcase-touchpad" src="https://github.com/user-attachments/assets/de07a740-1620-4df9-9256-ab258f3f0b44" />

As can be seen from gifs above, clicking on a mod in the list via touchpad (laptop) immediately starts reordering elements instead of opening an info screen. 

This change introduces distance based constraint for drag and drop, fixing the issue.

## Fixed 
<img width="1821" height="930" alt="IssueShowcaseFixed" src="https://github.com/user-attachments/assets/b2490375-e439-4547-acef-a0ea83cf1411" />