### PR TITLE
Prefer non-beta mod versions

### DIFF
--- a/src-tauri/src/profile/query.rs
+++ b/src-tauri/src/profile/query.rs
@@ -60,7 +60,7 @@ impl Queryable for QueryableProfileMod<'_> {
 
         match &self.kind {
             Kind::Local(local) => <LocalMod as Queryable>::version(local),
-            Kind::Thunderstore(remote) => Some(remote.package.latest().parsed_version()),
+            Kind::Thunderstore(remote) => Some(remote.package.latest_released().parsed_version()),
         }
     }
 

--- a/src-tauri/src/profile/update/mod.rs
+++ b/src-tauri/src/profile/update/mod.rs
@@ -63,12 +63,17 @@ impl Profile {
         };
 
         let package = thunderstore.get_package(current.package.uuid)?;
+        let current_version = current.version.parsed_version();
         let latest = BorrowedMod {
             package,
-            version: package.latest(),
+            version: if current_version.pre.is_empty() {
+                package.latest_released()
+            } else {
+                package.latest()
+            },
         };
 
-        if current.version.parsed_version() >= latest.version.parsed_version() {
+        if current_version >= latest.version.parsed_version() {
             return Ok(None);
         }
 

--- a/src-tauri/src/thunderstore/backend.rs
+++ b/src-tauri/src/thunderstore/backend.rs
@@ -186,7 +186,7 @@ impl ThunderstoreBackend {
     pub fn latest(&self) -> impl Iterator<Item = BorrowedMod<'_>> {
         self.packages.values().map(move |package| BorrowedMod {
             package,
-            version: package.latest(),
+            version: package.latest_released(),
         })
     }
 

--- a/src-tauri/src/thunderstore/mod.rs
+++ b/src-tauri/src/thunderstore/mod.rs
@@ -52,7 +52,7 @@ impl<'a> BorrowedMod<'a> {
     pub fn latest(package: &'a PackageListing) -> Self {
         Self {
             package,
-            version: package.latest(),
+            version: package.latest_released(),
         }
     }
 

--- a/src-tauri/src/thunderstore/models.rs
+++ b/src-tauri/src/thunderstore/models.rs
@@ -6,6 +6,7 @@ use std::{
 
 use chrono::{DateTime, Utc};
 use internment::Intern;
+use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 use uuid::Uuid;
 
@@ -47,6 +48,14 @@ impl PackageListing {
 
     pub fn latest(&self) -> &PackageVersion {
         &self.versions[0]
+    }
+
+    pub fn latest_released(&self) -> &PackageVersion {
+        &self
+            .versions
+            .iter()
+            .find_or_first(|v| v.parsed_version().pre.is_empty())
+            .unwrap()
     }
 
     pub fn is_modpack(&self) -> bool {

--- a/src/lib/components/mod-list/ModListItem.svelte
+++ b/src/lib/components/mod-list/ModListItem.svelte
@@ -4,7 +4,7 @@
 	import type { MouseEventHandler } from 'svelte/elements';
 	import Spinner from '../ui/Spinner.svelte';
 	import ModItemWithContext from './ModItemContext.svelte';
-	import { formatModName, isOutdated, modIconSrc, shortenNum, timeSince } from '$lib/util';
+	import { formatModName, hasNonReleaseUpgrade, isOutdated, modIconSrc, shortenNum, timeSince } from '$lib/util';
 
 	type Props = {
 		mod: Mod;
@@ -55,7 +55,11 @@
 					<Icon class="text-accent-500 shrink-0" icon="mdi:check-circle" />
 				{/if}
 				{#if isOutdated(mod)}
-					<Icon class="text-accent-500 shrink-0" icon="mdi:arrow-up-circle" />
+					{#if hasNonReleaseUpgrade(mod)}
+						<Icon class="text-accent-200 shrink-0" icon="mdi:flask-outline" />
+					{:else}
+						<Icon class="text-accent-500 shrink-0" icon="mdi:arrow-up-circle" />
+					{/if}
 				{/if}
 			</div>
 

--- a/src/lib/components/mod-list/ProfileModListItemNoContext.svelte
+++ b/src/lib/components/mod-list/ProfileModListItemNoContext.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import type { Mod } from '../../types';
 	import type { MouseEventHandler } from 'svelte/elements';
-	import { formatModName, isOutdated, modIconSrc } from '$lib/util';
+	import { formatModName, hasNonReleaseUpgrade, isOutdated, modIconSrc } from '$lib/util';
 	import Icon from '@iconify/svelte';
 	import type { Snippet } from 'svelte';
 	import type { ClassValue } from 'clsx';
@@ -55,7 +55,11 @@
 					<Icon class="mr-1 shrink-0 text-yellow-500" icon="mdi:warning" />
 				{/if}
 				{#if isOutdated(mod)}
-					<Icon class="text-accent-500 shrink-0" icon="mdi:arrow-up-circle" />
+					{#if hasNonReleaseUpgrade(mod)}
+						<Icon class="text-accent-200 shrink-0" icon="mdi:flask-outline" />
+					{:else}
+						<Icon class="text-accent-500 shrink-0" icon="mdi:arrow-up-circle" />
+					{/if}
 				{/if}
 			</div>
 

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -112,16 +112,22 @@ export function isOutdated(mod: Mod): boolean {
 	return mod.version !== mod.versions[0].name;
 }
 
+export function isNonReleaseVersion(version: string): boolean {
+	const metadataSeparator = version.indexOf('+');
+	const versionExtraSeparator = version.indexOf('-');
+	return versionExtraSeparator > 0 && (metadataSeparator < 0 ? 1 << 30 : metadataSeparator) > versionExtraSeparator;
+}
+
 export function hasNonReleaseUpgrade(mod: Mod): boolean {
 	if (mod.versions.length === 0) {
 		return false;
 	}
 
-	if (mod.version?.includes('-')) {
+	if (isNonReleaseVersion(mod.version ?? '')) {
 		return false;
 	}
 
-	return mod.versions[0].name.includes('-');
+	return isNonReleaseVersion(mod.versions[0].name);
 }
 
 export function communityUrl(backend: Backend, author: string, mod?: string) {

--- a/src/lib/util.ts
+++ b/src/lib/util.ts
@@ -112,6 +112,18 @@ export function isOutdated(mod: Mod): boolean {
 	return mod.version !== mod.versions[0].name;
 }
 
+export function hasNonReleaseUpgrade(mod: Mod): boolean {
+	if (mod.versions.length === 0) {
+		return false;
+	}
+
+	if (mod.version?.includes('-')) {
+		return false;
+	}
+
+	return mod.versions[0].name.includes('-');
+}
+
 export function communityUrl(backend: Backend, author: string, mod?: string) {
 	if (backend === Backend.Hexium) {
 		return `https://${games.active?.slug}.hexium.gg/${mod === undefined ? `teams/${author}` : `mods/${author}/${mod}`}`;

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -10,7 +10,7 @@
 		DependantWithVersion,
 		ListItem
 	} from '$lib/types';
-	import { isOutdated } from '$lib/util';
+	import { hasNonReleaseUpgrade, isOutdated } from '$lib/util';
 	import Icon from '@iconify/svelte';
 	import Dialog from '$lib/components/ui/Dialog.svelte';
 	import ModCardList from '$lib/components/ui/ModCardList.svelte';
@@ -270,9 +270,9 @@
 		<ModDetails {locked} mod={selectedMod} {contextItems} onclose={() => (selectedMod = null)}>
 			{#if isOutdated(selectedMod) && !locked}
 				<Button
-					color="accent"
+					color={hasNonReleaseUpgrade(selectedMod) ? "primary" : "accent"}
 					size="lg"
-					icon="mdi:arrow-up-circle"
+					icon={hasNonReleaseUpgrade(selectedMod) ? "mdi:flask-outline" : "mdi:arrow-up-circle"}
 					class="mt-2"
 					onclick={() => updateMod(selectedMod)}
 				>


### PR DESCRIPTION
Specifically, semver versions with any prefix.

Meaning, when you have a mod with a beta version, installing said mod will install the latest released version.

Specific installed mods will indicate that there are beta updates, but "Update all" will never install the beta, unless the mod is currently beta.

You always can manually switch the version to any available version including betas.