### PR TITLE
fix: persist UI state in tauri store instead of localStorage

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
 		"@sveltejs/kit": "^2.63.0",
 		"@sveltejs/vite-plugin-svelte": "^7.1.2",
 		"@tailwindcss/vite": "^4.3.0",
+		"@tauri-apps/cli": "^2.11.4",
 		"@types/node": "^25.9.2",
 		"prettier": "^3.8.1",
 		"prettier-plugin-svelte": "^3.4.1",
@@ -46,6 +47,7 @@
 		"@tauri-apps/plugin-os": "^2.3.2",
 		"@tauri-apps/plugin-process": "^2.3.1",
 		"@tauri-apps/plugin-shell": "^2.3.4",
+		"@tauri-apps/plugin-store": "^2.4.4",
 		"@tauri-apps/plugin-updater": "^2.10.0",
 		"bits-ui": "^2.15.4",
 		"clsx": "^2.1.1",
@@ -53,7 +55,6 @@
 		"js-convert-case": "^4.2.0",
 		"rehype-highlight": "^7.0.2",
 		"rehype-raw": "^7.0.0",
-		"runed": "^0.29.2",
 		"svelte-exmarkdown": "^5.0.2"
 	}
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@tauri-apps/plugin-shell':
         specifier: ^2.3.4
         version: 2.3.4
+      '@tauri-apps/plugin-store':
+        specifier: ^2.4.4
+        version: 2.4.4
       '@tauri-apps/plugin-updater':
         specifier: ^2.10.0
         version: 2.10.1
@@ -56,9 +59,6 @@ importers:
       rehype-raw:
         specifier: ^7.0.0
         version: 7.0.0
-      runed:
-        specifier: ^0.29.2
-        version: 0.29.2(svelte@5.56.2)
       svelte-exmarkdown:
         specifier: ^5.0.2
         version: 5.0.2(svelte@5.56.2)
@@ -84,6 +84,9 @@ importers:
       '@tailwindcss/vite':
         specifier: ^4.3.0
         version: 4.3.0(vite@8.0.16(@types/node@25.9.2)(jiti@2.6.1))
+      '@tauri-apps/cli':
+        specifier: ^2.11.4
+        version: 2.11.4
       '@types/node':
         specifier: ^25.9.2
         version: 25.9.2
@@ -475,6 +478,82 @@ packages:
   '@tauri-apps/api@2.9.1':
     resolution: {integrity: sha512-IGlhP6EivjXHepbBic618GOmiWe4URJiIeZFlB7x3czM0yDHHYviH1Xvoiv4FefdkQtn6v7TuwWCRfOGdnVUGw==}
 
+  '@tauri-apps/cli-darwin-arm64@2.11.4':
+    resolution: {integrity: sha512-1ryOF3ZhpZ/nemHV5zVwBQBz9jDGKmKPvWPADOhc83ig0P4bMc2iER4NbC6r9sjeIZ6RVQ4g3RZIYvezhcl4TQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tauri-apps/cli-darwin-x64@2.11.4':
+    resolution: {integrity: sha512-uFsGQAAfuyz1k/yGLmkWfkBlgKAqZfxqlHmLWx81QU27RJWfmbNHCIq8T8w1e+VClleIuZUjpHWfoE4E3DLo3A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.4':
+    resolution: {integrity: sha512-IaHZn5CdBL21oUmjiVOS1ctw6Ip1O0pjp70FwOWmYz1myWe0SY96ZIj2FYf7pT0m8bI2h/hrs5ZbEXXh44/MkQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.4':
+    resolution: {integrity: sha512-N41/ukTRVe6XSuUTESuFdGeOW2i7k62tK+6gHK5Kd5/q5RPvvi19GaWAVPPb9u95HSGmTChSolBfzynUsssFaA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tauri-apps/cli-linux-arm64-musl@2.11.4':
+    resolution: {integrity: sha512-v277UnT/fB64xAfSroL5N3Km3tLmvATWqJJw/wRI+g6o+HkeD0slyE7gOhNs1MbjE41R7bQOTxMVoL3aomUJmw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
+    resolution: {integrity: sha512-qqgNkQ2u1yZHxjhxsZaxUtRDW8dIqIYm33rx/mzwQv0SfY9x1B+iraj8vWeFiXjjSVVhEMepXSOts1TqPzvXNQ==}
+    engines: {node: '>= 10'}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tauri-apps/cli-linux-x64-gnu@2.11.4':
+    resolution: {integrity: sha512-2VRNWl84FOH0m2giiDkO2h0QXlcMJeX+zJDpI5kDIQAx6s+geF3v48F4DXfJez4GS/FdoDGnPnw1C2iYGbQ7bQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tauri-apps/cli-linux-x64-musl@2.11.4':
+    resolution: {integrity: sha512-o9GyhYor/nc7xarmwDE3ka2szuW3uuZzXjHWh64Q8YX5AtSgxdQkFWzrY4O8KiGtVNvFBI14H3Q49Qj5TOIP/A==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
+    resolution: {integrity: sha512-ld5Ehb598m0VkYyylRPNeCFsBe/km0jxis6KgMpl3IGY6I/i1RwQXO05I1AsXUXO2WC6AvB/Lw4qTf/asiuEiQ==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.4':
+    resolution: {integrity: sha512-12Hxi0XX/H5VFxO/bGgHkFWhml9VMgEOu9CidjeCeTNQ1l6fpUlbiGgSP7CLI3PFtW9/FfbeHieZ+kyWK5H7CA==}
+    engines: {node: '>= 10'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@tauri-apps/cli-win32-x64-msvc@2.11.4':
+    resolution: {integrity: sha512-+vDiqBIU5dMISg/wNvX3sF+ZHfgJGJ5T0AcO+EHNXV9GGAG+P5fzodlDXD3QdKCRgZxMoCm5PPvj3BqLNjBthw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tauri-apps/cli@2.11.4':
+    resolution: {integrity: sha512-R8xGtMpwyetawSqm9kYOuMmEqkhUbvcUy8n0aNXIxollKBLESUu5f4Fx+64hgASYm1H+jSWq6jCW6zqTnH6hqQ==}
+    engines: {node: '>= 10'}
+    hasBin: true
+
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
 
@@ -492,6 +571,9 @@ packages:
 
   '@tauri-apps/plugin-shell@2.3.4':
     resolution: {integrity: sha512-ktsRWf8wHLD17aZEyqE8c5x98eNAuTizR1FSX475zQ4TxaiJnhwksLygQz+AGwckJL5bfEP13nWrlTNQJUpKpA==}
+
+  '@tauri-apps/plugin-store@2.4.4':
+    resolution: {integrity: sha512-oxSMaj/QpVfJcBMYX5aOQV94fWvga0MwQMfD6TLlbK2dh+ShPWAzefd8HWXhvOKjPRJdGVAkW7ZGO76JzzjaDA==}
 
   '@tauri-apps/plugin-updater@2.10.1':
     resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
@@ -1103,11 +1185,6 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  runed@0.29.2:
-    resolution: {integrity: sha512-0cq6cA6sYGZwl/FvVqjx9YN+1xEBu9sDDyuWdDW1yWX7JF2wmvmVKfH+hVCZs+csW+P3ARH92MjI3H9QTagOQA==}
-    peerDependencies:
-      svelte: ^5.7.0
-
   runed@0.35.1:
     resolution: {integrity: sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==}
     peerDependencies:
@@ -1662,6 +1739,53 @@ snapshots:
 
   '@tauri-apps/api@2.9.1': {}
 
+  '@tauri-apps/cli-darwin-arm64@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-darwin-x64@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm-gnueabihf@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm64-gnu@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-arm64-musl@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-riscv64-gnu@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-x64-gnu@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-linux-x64-musl@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-win32-arm64-msvc@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-win32-ia32-msvc@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli-win32-x64-msvc@2.11.4':
+    optional: true
+
+  '@tauri-apps/cli@2.11.4':
+    optionalDependencies:
+      '@tauri-apps/cli-darwin-arm64': 2.11.4
+      '@tauri-apps/cli-darwin-x64': 2.11.4
+      '@tauri-apps/cli-linux-arm-gnueabihf': 2.11.4
+      '@tauri-apps/cli-linux-arm64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-arm64-musl': 2.11.4
+      '@tauri-apps/cli-linux-riscv64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-x64-gnu': 2.11.4
+      '@tauri-apps/cli-linux-x64-musl': 2.11.4
+      '@tauri-apps/cli-win32-arm64-msvc': 2.11.4
+      '@tauri-apps/cli-win32-ia32-msvc': 2.11.4
+      '@tauri-apps/cli-win32-x64-msvc': 2.11.4
+
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     dependencies:
       '@tauri-apps/api': 2.9.1
@@ -1685,6 +1809,10 @@ snapshots:
   '@tauri-apps/plugin-shell@2.3.4':
     dependencies:
       '@tauri-apps/api': 2.9.1
+
+  '@tauri-apps/plugin-store@2.4.4':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-updater@2.10.1':
     dependencies:
@@ -2397,11 +2525,6 @@ snapshots:
       '@rolldown/binding-wasm32-wasi': 1.0.3
       '@rolldown/binding-win32-arm64-msvc': 1.0.3
       '@rolldown/binding-win32-x64-msvc': 1.0.3
-
-  runed@0.29.2(svelte@5.56.2):
-    dependencies:
-      esm-env: 1.2.2
-      svelte: 5.56.2
 
   runed@0.35.1(@sveltejs/kit@2.63.0(@sveltejs/vite-plugin-svelte@7.1.2(svelte@5.56.2)(vite@8.0.16(@types/node@25.9.2)(jiti@2.6.1)))(svelte@5.56.2)(typescript@5.9.3)(vite@8.0.16(@types/node@25.9.2)(jiti@2.6.1)))(svelte@5.56.2):
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2020,6 +2020,7 @@ dependencies = [
  "tauri-plugin-process",
  "tauri-plugin-shell",
  "tauri-plugin-single-instance",
+ "tauri-plugin-store",
  "tauri-plugin-updater",
  "tauri-plugin-window-state",
  "tempfile",
@@ -5967,6 +5968,22 @@ dependencies = [
  "tracing",
  "windows-sys 0.60.2",
  "zbus",
+]
+
+[[package]]
+name = "tauri-plugin-store"
+version = "2.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6708afbe549f176b712066e71648ba8fafba20789453718260c7ca356733cb0c"
+dependencies = [
+ "dunce",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -28,6 +28,7 @@ tauri-plugin-process = "2"
 tauri-plugin-updater = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-single-instance = { version = "2.3.2", features = ["deep-link"] }
+tauri-plugin-store = "2"
 
 serde_json = "1"
 serde = { version = "1", features = ["derive"] }

--- a/src-tauri/capabilities/main.json
+++ b/src-tauri/capabilities/main.json
@@ -21,6 +21,7 @@
 		"updater:allow-check",
 		"dialog:default",
 		"shell:default",
-		"os:allow-locale"
+		"os:allow-locale",
+		"store:default"
 	]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -213,6 +213,7 @@ pub fn run() {
         .plugin(tauri_plugin_clipboard_manager::init())
         .plugin(tauri_plugin_window_state::Builder::new().build())
         .plugin(tauri_plugin_single_instance::init(handle_single_instance))
+        .plugin(tauri_plugin_store::Builder::new().build())
         .setup(setup)
         .build(tauri::generate_context!())
         .expect("error while running tauri application")

--- a/src/lib/components/menubar/Menubar.svelte
+++ b/src/lib/components/menubar/Menubar.svelte
@@ -19,7 +19,7 @@
 
 	import { capitalize, fileToBase64, shortenFileSize } from '$lib/util';
 	import * as api from '$lib/api';
-	import { useNativeMenu } from '$lib/theme';
+	import { useNativeMenu } from '$lib/theme.svelte';
 
 	import { confirm, open } from '@tauri-apps/plugin-dialog';
 	import { getCurrentWindow } from '@tauri-apps/api/window';

--- a/src/lib/components/prefs/ColorPref.svelte
+++ b/src/lib/components/prefs/ColorPref.svelte
@@ -9,7 +9,7 @@
 		type Color,
 		systemAccentColorPromise,
 		colorFallbacks
-	} from '$lib/theme';
+	} from '$lib/theme.svelte';
 	import { selectItems } from '$lib/util';
 	import Select from '$lib/components/ui/Select.svelte';
 	import Icon from '@iconify/svelte';
@@ -27,7 +27,7 @@
 
 	let { category, children }: Props = $props();
 
-	let value = $state(getColor(category));
+	const value = $derived(getColor(category));
 
 	const selectOptions = $derived(
 		selectItems(
@@ -64,7 +64,6 @@
 	};
 
 	function set(color: Color) {
-		value = color;
 		setColor(category, color);
 	}
 

--- a/src/lib/components/prefs/FontFamilyPref.svelte
+++ b/src/lib/components/prefs/FontFamilyPref.svelte
@@ -3,7 +3,7 @@
 	import Combobox from '$lib/components/ui/Combobox.svelte';
 	import ResetButton from '$lib/components/ui/ResetButton.svelte';
 	import { selectItems } from '$lib/util';
-	import { getFont, setFont } from '$lib/theme';
+	import { getFont, setFont } from '$lib/theme.svelte';
 	import { onMount } from 'svelte';
 	import * as api from '$lib/api';
 	import { m } from '$lib/paraglide/messages';

--- a/src/lib/components/toolbar/LaunchButton.svelte
+++ b/src/lib/components/toolbar/LaunchButton.svelte
@@ -12,7 +12,7 @@
 	import DropdownArrow from '../ui/DropdownArrow.svelte';
 	import ContextMenuContent from '../ui/ContextMenuContent.svelte';
 	import { type ContextItem } from '$lib/types';
-	import { PersistedState } from 'runed';
+	import { PersistedState } from '$lib/state/persisted-state.svelte';
 
 	type Mode = 'vanilla' | 'modded';
 

--- a/src/lib/components/toolbar/SyncDonationNotice.svelte
+++ b/src/lib/components/toolbar/SyncDonationNotice.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { PersistedState } from 'runed';
+	import { PersistedState } from '$lib/state/persisted-state.svelte';
 	import Link from '../ui/Link.svelte';
 	import Icon from '@iconify/svelte';
 	import InfoBox from '../ui/InfoBox.svelte';

--- a/src/lib/components/toolbar/Toolbar.svelte
+++ b/src/lib/components/toolbar/Toolbar.svelte
@@ -18,7 +18,7 @@
 	import DropdownArrow from '../ui/DropdownArrow.svelte';
 	import ContextMenuContent from '../ui/ContextMenuContent.svelte';
 	import { type ContextItem } from '$lib/types';
-	import { PersistedState } from 'runed';
+	import { PersistedState } from '$lib/state/persisted-state.svelte';
 
 	type Mode = 'vanilla' | 'modded';
 

--- a/src/lib/state/misc.svelte.ts
+++ b/src/lib/state/misc.svelte.ts
@@ -1,5 +1,5 @@
 import { Backend, type ConfigEntryId, type QueryModsArgsWithoutMax } from '$lib/types';
-import { PersistedState } from 'runed';
+import { PersistedState } from '$lib/state/persisted-state.svelte';
 
 export const apiKeyDialog = $state({
 	open: false,

--- a/src/lib/state/persisted-state.svelte.ts
+++ b/src/lib/state/persisted-state.svelte.ts
@@ -1,0 +1,100 @@
+import { LazyStore } from '@tauri-apps/plugin-store';
+
+const uiStore = new LazyStore('ui-state.json', { autoSave: true });
+
+type Serializer<T> = {
+	serialize: (value: T) => string;
+	deserialize: (value: string) => T | undefined;
+};
+
+type PersistedStateOptions<T> = {
+	/**
+	 * The serializer to use.
+	 *
+	 * @default { serialize: JSON.stringify, deserialize: JSON.parse }
+	 */
+	serializer?: Serializer<T>;
+};
+
+const DEFAULT_SERIALIZER: Serializer<unknown> = {
+	serialize: JSON.stringify,
+	deserialize: JSON.parse
+};
+
+const instances = new Map<string, PersistedState<unknown>[]>();
+
+// Writes are gated on this so the constructor's eager effect cannot overwrite
+// persisted values with the initial defaults before the store has been read.
+let loaded = false;
+
+async function load(): Promise<void> {
+	try {
+		await uiStore.init();
+		for (const [key, value] of await uiStore.entries<string>()) {
+			for (const instance of instances.get(key) ?? []) {
+				instance.hydrate(value);
+			}
+		}
+		loaded = true;
+	} catch (error) {
+		console.error('Error when loading persisted store', error);
+	}
+}
+
+void load();
+
+/**
+ * Reactive state persisted to the Tauri store (`ui-state.json`).
+ *
+ * Reads return the initial value until the store has loaded, then reactively swap to the persisted value. Every change (including deep mutations of nested state) is written back to the store.
+ */
+export class PersistedState<T> {
+	#value = $state<T>() as T;
+	#key: string;
+	#serializer: Serializer<T>;
+
+	constructor(key: string, initialValue: T, options: PersistedStateOptions<T> = {}) {
+		this.#key = key;
+		this.#serializer = options.serializer ?? (DEFAULT_SERIALIZER as Serializer<T>);
+		this.#value = initialValue;
+
+		const list = instances.get(key) ?? [];
+		list.push(this as unknown as PersistedState<unknown>);
+		instances.set(key, list);
+
+		$effect.root(() => {
+			$effect(() => {
+				// Reading the value unconditionally keeps the effect subscribed;
+				// gating only the write prevents clobbering persisted values
+				// with the initial defaults before the store has been read.
+				const value = this.#value;
+				if (loaded) {
+					void uiStore.set(this.#key, this.#serializer.serialize(value));
+				}
+			});
+		});
+	}
+
+	get current(): T {
+		return this.#value;
+	}
+
+	set current(value: T) {
+		this.#value = value;
+	}
+
+	hydrate(value: string): void {
+		const parsed = this.#deserialize(value);
+		if (parsed !== undefined) {
+			this.#value = parsed;
+		}
+	}
+
+	#deserialize(value: string): T | undefined {
+		try {
+			return this.#serializer.deserialize(value);
+		} catch (error) {
+			console.error(`Error when parsing persisted store value for "${this.#key}"`, error);
+		}
+	}
+}

--- a/src/lib/theme.svelte.ts
+++ b/src/lib/theme.svelte.ts
@@ -1,5 +1,5 @@
 import { platform } from '@tauri-apps/plugin-os';
-import { PersistedState } from 'runed';
+import { PersistedState } from '$lib/state/persisted-state.svelte';
 import getPalette from 'tailwindcss-palette-generator';
 import * as api from '$lib/api';
 import type { RgbaColor } from './types';
@@ -315,6 +315,9 @@ export const colorFallbacks: Record<ColorCategory, Color> = {
 	primary: { type: 'default', name: 'gray' }
 };
 
+const accentColor = new PersistedState<Color>('accentColor', colorFallbacks.accent);
+const primaryColor = new PersistedState<Color>('primaryColor', colorFallbacks.primary);
+
 export const systemAccentColorPromise = api.prefs.getSystemAccentColor().then((color) => {
 	if (color) {
 		return rgbToHex(color);
@@ -364,48 +367,47 @@ async function getShades(
 	}
 }
 
-export async function setColor(category: ColorCategory, color: Color) {
-	let shades = await getShades(category, color);
-
+async function applyShades(category: ColorCategory, color: Color) {
+	const shades = await getShades(category, color);
 	for (const [shade, value] of Object.entries(shades)) {
 		root.style.setProperty(`--color-${category}-${shade}`, value);
 	}
+}
 
-	localStorage.setItem(category + 'Color', JSON.stringify(color));
+$effect.root(() => {
+	$effect(() => {
+		void applyShades('accent', accentColor.current);
+	});
+
+	$effect(() => {
+		void applyShades('primary', primaryColor.current);
+	});
+});
+
+export function setColor(category: ColorCategory, color: Color) {
+	(category === 'accent' ? accentColor : primaryColor).current = color;
 }
 
 export function getColor(category: ColorCategory): Color {
-	let json = localStorage.getItem(category + 'Color');
-
-	if (json === null) {
-		return colorFallbacks[category];
-	}
-
-	try {
-		return JSON.parse(json) as Color;
-	} catch (e) {
-		console.error('Failed to parse saved color', e);
-		return colorFallbacks[category];
-	}
-}
-
-export function refreshColor(category: ColorCategory) {
-	setColor(category, getColor(category));
+	return (category === 'accent' ? accentColor : primaryColor).current;
 }
 
 const defaultFont = 'Inter';
 
+const font = new PersistedState<string>('font', defaultFont);
+
+$effect.root(() => {
+	$effect(() => {
+		root.style.fontFamily = `'${font.current}', '${defaultFont}', sans-serif`;
+	});
+});
+
 export function setFont(fontFamily: string) {
-	root.style.fontFamily = `'${fontFamily}', '${defaultFont}', sans-serif`;
-	localStorage.setItem('font', fontFamily);
+	font.current = fontFamily;
 }
 
 export function getFont() {
-	return localStorage.getItem('font') ?? defaultFont;
-}
-
-export function refreshFont() {
-	setFont(getFont());
+	return font.current;
 }
 
 export const useNativeMenu = new PersistedState(

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -9,7 +9,6 @@
 	import Toasts from '$lib/components/misc/Toasts.svelte';
 
 	import { onMount, type Snippet } from 'svelte';
-	import { refreshColor, refreshFont } from '$lib/theme';
 	import InstallModDialog from '$lib/components/dialogs/InstallModDialog.svelte';
 	import WelcomeDialog from '$lib/components/dialogs/WelcomeDialog.svelte';
 	import Navbar from '$lib/components/misc/Navbar.svelte';
@@ -30,9 +29,6 @@
 	let unlistenGames: UnlistenFn | null;
 
 	onMount(() => {
-		refreshFont();
-		refreshColor('accent');
-		refreshColor('primary');
 		refreshLanguage();
 
 		$effect(() => {

--- a/src/routes/prefs/+page.svelte
+++ b/src/routes/prefs/+page.svelte
@@ -18,7 +18,7 @@
 	import ColorPref from '$lib/components/prefs/ColorPref.svelte';
 
 	import Label from '$lib/components/ui/Label.svelte';
-	import { useNativeMenu } from '$lib/theme';
+	import { useNativeMenu } from '$lib/theme.svelte';
 	import Checkbox from '$lib/components/ui/Checkbox.svelte';
 	import games from '$lib/state/game.svelte';
 	import profiles from '$lib/state/profile.svelte';


### PR DESCRIPTION
fixes #687 by basically using tauri's store plugin instead of local storage. I copied persisted-state.svelte.ts from runed and edited it to work with tauri store instead to avoid changing the PersistedState consumers.