### PR TITLE
linux: lower the priority of steam.sh

### DIFF
--- a/src-tauri/src/profile/launch/platform.rs
+++ b/src-tauri/src/profile/launch/platform.rs
@@ -105,18 +105,6 @@ fn create_base_steam_command() -> Result<Command> {
 
     // return Ok(Command::new("/home/keso/.local/share/Steam/steam.sh"));
 
-    debug!("checking for steam.sh script in steam installation directory");
-
-    match locate_steam_script() {
-        Ok(path) => {
-            info!("found steam.sh script at {}", path.display());
-            return Ok(Command::new(path));
-        }
-        Err(err) => {
-            debug!("failed to locate steam.sh script: {:#}", err);
-        }
-    };
-
     debug!("checking for steam system installation with which");
 
     if let Ok(path) = which::which("steam") {
@@ -137,6 +125,18 @@ fn create_base_steam_command() -> Result<Command> {
 
         return Ok(command);
     }
+
+    debug!("checking for steam.sh script in steam installation directory");
+
+    match locate_steam_script() {
+        Ok(path) => {
+            info!("found steam.sh script at {}", path.display());
+            return Ok(Command::new(path));
+        }
+        Err(err) => {
+            debug!("failed to locate steam.sh script: {:#}", err);
+        }
+    };
 
     let path = Path::new("/usr/bin/steam")
         .exists_or_none()


### PR DESCRIPTION
This breaks many linux systems that need to do runtime setup to actually run steam. Always prefer the `steam` in $PATH. If user uses flatpak steam that also should be preferred over `steam.sh`.

I'm not even sure if `steam.sh` should ever be used directly, but I'm going to leave it here as low prio.

Future improvement would be to be able to configure steam path on linux as well.