### PR TITLE
Fix How to Fish path

### DIFF
--- a/src-tauri/games.json
+++ b/src-tauri/games.json
@@ -1419,7 +1419,8 @@
 		},
 		"platforms": {
 			"steam": {
-				"id": 4001890
+				"id": 4001890,
+				"dirName": "How to Fish/How to Fish"
 			}
 		},
 		"backends": ["Thunderstore", "Hexium"]


### PR DESCRIPTION
Manually specifies the path for How to Fish as for some reason the actual game files are in a subdirectory in the main game directory.

(See SteamDB file listing for e.g. [Balatro](https://steamdb.info/depot/2379781/) and [How to Fish](https://steamdb.info/depot/4001891/) for reference, `How to Fish.exe` is listed under `How to Fish/How to Fish.exe` while Balatro's executable is listed by itself.)